### PR TITLE
Improve Makefile.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: cpp
 compiler:
     - gcc
     - clang
-script: make
+script: make CXX=${CXX}

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,31 @@
-DIR_INC = ./inc
-DIR_SRC = ./src
-DIR_OBJ = ./obj
-BINDIR=/usr/local/bin
+DIR_INC := ./inc
+DIR_SRC := ./src
+DIR_OBJ := ./obj
 
-SRC = $(wildcard ${DIR_SRC}/*.cpp)  
-OBJ = $(patsubst %.cpp,${DIR_OBJ}/%.o,$(notdir ${SRC})) 
+PREFIX := /usr/local
+BINDIR := $(PREFIX)/bin
+INCLUDE_DIRS :=
+LIBRARY_DIRS :=
 
-TARGET = fastp
+SRC := $(wildcard ${DIR_SRC}/*.cpp)
+OBJ := $(patsubst %.cpp,${DIR_OBJ}/%.o,$(notdir ${SRC}))
 
-BIN_TARGET = ${TARGET}
+TARGET := fastp
 
-CC = g++
-CFLAGS = -std=c++11 -g -I${DIR_INC}
+BIN_TARGET := ${TARGET}
+
+CXX := g++
+CXXFLAGS := -std=c++11 -g -I${DIR_INC} $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir))
+LIBS := -lz -lpthread
+LD_FLAGS := $(foreach librarydir,$(LIBRARY_DIRS),-L$(librarydir)) $(LIBS)
+
 
 ${BIN_TARGET}:${OBJ}
-	$(CC) $(OBJ) -lz -lpthread -o $@
-    
+	$(CXX) $(OBJ) -o $@ $(LD_FLAGS)
+
 ${DIR_OBJ}/%.o:${DIR_SRC}/%.cpp make_obj_dir
-	$(CC) $(CFLAGS) -O3 -c  $< -o $@
+	$(CXX) $(CXXFLAGS) -O3 -c $< -o $@
+
 .PHONY:clean
 clean:
 	rm obj/*.o
@@ -30,5 +38,5 @@ make_obj_dir:
 	fi
 
 install:
-	install $(TARGET) $(BINDIR)/$(TARGET)
+	install -D $(TARGET) $(BINDIR)/$(TARGET)
 	@echo "Installed."

--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -169,8 +169,8 @@ bool PairEndProcessor::process(){
     delete finalPostStats2;
     delete finalFilterResult;
 
-    delete threads;
-    delete configs;
+    delete[] threads;
+    delete[] configs;
 
     if(!mOptions->split.enabled)
         closeOutput();
@@ -414,7 +414,7 @@ void PairEndProcessor::producerTask()
 
     // if the last data initialized is not used, free it
     if(data != NULL)
-        delete data;
+        delete[] data;
 }
 
 void PairEndProcessor::consumerTask(ThreadConfig* config)

--- a/src/seprocessor.cpp
+++ b/src/seprocessor.cpp
@@ -141,8 +141,8 @@ bool SingleEndProcessor::process(){
     delete finalPostStats;
     delete finalFilterResult;
 
-    delete threads;
-    delete configs;
+    delete[] threads;
+    delete[] configs;
 
     if(!mOptions->split.enabled)
         closeOutput();
@@ -350,7 +350,7 @@ void SingleEndProcessor::producerTask()
 
     // if the last data initialized is not used, free it
     if(data != NULL)
-        delete data;
+        delete[] data;
 }
 
 void SingleEndProcessor::consumerTask(ThreadConfig* config)

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -778,7 +778,7 @@ void Stats::reportHtmlQuality(ofstream& ofs, string filteringType, string readNa
     ofs << json_str;
     ofs << "</script>" << endl;
 
-    delete x;
+    delete[] x;
 }
 
 void Stats::reportHtmlContents(ofstream& ofs, string filteringType, string readName) {
@@ -865,7 +865,7 @@ void Stats::reportHtmlContents(ofstream& ofs, string filteringType, string readN
     ofs << json_str;
     ofs << "</script>" << endl;
 
-    delete x;
+    delete[] x;
 }
 
 Stats* Stats::merge(vector<Stats*>& list) {


### PR DESCRIPTION
Improve Makefile:
  - Use CXX and CXXFLAGS (C++ compiler related flags) instead of
    CC and CFLAGS.
  - Add PREFIX variable (is used to contruct BINDIR).
  - Add INCLUDE_DIRS variable so paths to header files for zlib and
    pthreads libraries can be set.
  - Add LIBRARY_DIRS variable so paths to libraries can be set.
  - Add LIBS variable to define which libraries should be linked.
  - Add LD_FLAGS which combines LIBRARY_DIRS with LIBS.
  - Create destination parent directory in case it does not exist
    when installing the compiled binary with "make install".

Example:

    make \
        PREFIX=/software/fastp \
        INCLUDE_DIRs=/software/zlib/1.2.8/include \
        LIBRARY_DIRS=/software/zlib/1.2.8/lib