### PR TITLE
Update Makefile so variables can be set from the command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ DIR_INC := ./inc
 DIR_SRC := ./src
 DIR_OBJ := ./obj
 
-PREFIX := /usr/local
-BINDIR := $(PREFIX)/bin
-INCLUDE_DIRS :=
-LIBRARY_DIRS :=
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+INCLUDE_DIRS ?=
+LIBRARY_DIRS ?=
 
 SRC := $(wildcard ${DIR_SRC}/*.cpp)
 OBJ := $(patsubst %.cpp,${DIR_OBJ}/%.o,$(notdir ${SRC}))


### PR DESCRIPTION
Update Makefile so the PREFIX et al. variables can be set from the command line
e.g.: `make PREFIX=/another/location`

https://www.gnu.org/software/make/manual/make.html#Reading-Makefiles