### PR TITLE
Allow usage of system zlib headers for dynamic linking

### DIFF
--- a/src/fastqreader.h
+++ b/src/fastqreader.h
@@ -4,7 +4,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "read.h"
-#include "zlib/zlib.h"
+#ifdef DYNAMIC_ZLIB
+  #include <zlib.h>
+#else
+  #include "zlib/zlib.h"
+#endif
 #include "common.h"
 #include <iostream>
 #include <fstream>

--- a/src/writer.h
+++ b/src/writer.h
@@ -3,7 +3,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "zlib/zlib.h"
+#ifdef DYNAMIC_ZLIB
+  #include <zlib.h>
+#else
+  #include "zlib/zlib.h"
+#endif
 #include "common.h"
 #include <iostream>
 #include <fstream>


### PR DESCRIPTION
This will help us remove a required [patch](https://salsa.debian.org/med-team/fastp/blob/master/debian/patches/use_debian_packaged_zlib.patch) for Debian packaging.

The reason can be found [here](https://wiki.debian.org/UpstreamGuide#No_inclusion_of_third_party_code).