### PR TITLE
some minor bug found, hopefuly my modifications are valid~

### DIFF
--- a/src/adaptertrimmer.cpp
+++ b/src/adaptertrimmer.cpp
@@ -84,7 +84,7 @@ bool AdapterTrimmer::trimBySequence(Read* r, FilterResult* fr, string& adapterse
 
     if(found) {
         if(pos < 0) {
-            string adapter = adapterseq.substr(0, alen+pos);
+            string adapter = adapterseq.substr(-pos, alen+pos);
             r->mSeq.mStr.resize(0);
             r->mQuality.resize(0);
             if(fr) {

--- a/src/evaluator.cpp
+++ b/src/evaluator.cpp
@@ -195,10 +195,10 @@ void Evaluator::evaluateReadNum(long& readNum) {
     readNum = 0;
     if(reachedEOF){
         readNum = records;
-    } else if(records>0) {
+    } else if(records>1) {
         // by the way, update readNum so we don't need to evaluate it if splitting output is enabled
         reader.getBytes(bytesRead, bytesTotal);
-        double bytesPerRead = (double)(bytesRead - firstReadPos) / (double) records;
+        double bytesPerRead = (double)(bytesRead - firstReadPos) / (double) (records - 1);
         // increase it by 1% since the evaluation is usually a bit lower due to bad quality causes lower compression rate
         readNum = (long) (bytesTotal*1.01 / bytesPerRead);
     }
@@ -281,10 +281,10 @@ string Evaluator::evalAdapterAndReadNumDepreciated(long& readNum) {
     readNum = 0;
     if(reachedEOF){
         readNum = records;
-    } else if(records>0) {
+    } else if(records>1) {
         // by the way, update readNum so we don't need to evaluate it if splitting output is enabled
         reader.getBytes(bytesRead, bytesTotal);
-        double bytesPerRead = (double)(bytesRead - firstReadPos) / (double) records;
+        double bytesPerRead = (double)(bytesRead - firstReadPos) / (double) (records - 1);
         // increase it by 1% since the evaluation is usually a bit lower due to bad quality causes lower compression rate
         readNum = (long) (bytesTotal*1.01 / bytesPerRead);
     }

--- a/src/evaluator.cpp
+++ b/src/evaluator.cpp
@@ -447,10 +447,10 @@ string Evaluator::evalAdapterAndReadNum(long& readNum, bool isR2) {
     readNum = 0;
     if(reachedEOF){
         readNum = records;
-    } else if(records>0) {
+    } else if(records>1) {
         // by the way, update readNum so we don't need to evaluate it if splitting output is enabled
         reader.getBytes(bytesRead, bytesTotal);
-        double bytesPerRead = (double)(bytesRead - firstReadPos) / (double) records;
+        double bytesPerRead = (double)(bytesRead - firstReadPos) / (double) (records - 1);
         // increase it by 1% since the evaluation is usually a bit lower due to bad quality causes lower compression rate
         readNum = (long) (bytesTotal*1.01 / bytesPerRead);
     }


### PR DESCRIPTION
thank you for providing such a excellent opensource fastq preprocessor, I have studied your code recently and found s minor some minor bugs:
1, the adapter sequence should be the overlap part of external provided adapterseq and the fastq read seq? If so, I think my modification is reasonable, if not, I would appreciate your idea about this treating

2, during the estimation of read number of a fastq file, the left bytes shouldn't take the first read into account, so I think the divisor records should minus 1
check it here: 