### PR TITLE
Rename --polyX --> --trim_poly_x in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ For Illumina NextSeq/NovaSeq data, `polyG` can happen in read tails since `G` me
 A minimum length can be set with `<poly_g_min_len>` for `fastp` to detect polyG. This value is 10 by default.
 
 # polyX tail trimming
-This feature is similar as polyG tail trimming, but is disabled by default. Use `-x` or `--polyX` to enable it. A minimum length can be set with `<poly_x_min_len>` for `fastp` to detect polyX. This value is 10 by default.   
+This feature is similar as polyG tail trimming, but is disabled by default. Use `-x` or `--trim_poly_x` to enable it. A minimum length can be set with `<poly_x_min_len>` for `fastp` to detect polyX. This value is 10 by default.   
 
 When `polyG tail trimming` and `polyX tail trimming` are both enabled, fastp will perform `polyG trimming` first, then perform `polyX trimming`. This setting is useful for trimming the tails having `polyX (i.e. polyA) ` before `polyG`. `polyG` is usually caused by sequencing artifacts, while `polyA` can be commonly found from the tails of mRNA-Seq reads.
 


### PR DESCRIPTION
Hello,
Thanks again for making this package! It's my favorite read trimmer and merger. I made the mistake of not fully reading the help text and just copy/pasted from the documentation and ran into some errors (https://github.com/czbiohub/nf-predictorthologs/pull/60). Turns out the flag to turn on polyX trimming is `--trim_poly_x` not `--polyX` so this PR fixes that.
Thanks!
Olga