### PR TITLE
Pad loginfo time with a zero

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -267,7 +267,7 @@ inline void loginfo(const string s){
     logmtx.lock();
     time_t tt = time(NULL);
     tm* t= localtime(&tt);
-    cerr<<"["<<t->tm_hour<<":"<<t->tm_min<<":"<<t->tm_sec<<"] "<<s<<endl;
+    fprintf(stderr, "[%02d:%02d:%02d]\n", t->tm_hour, t->tm_min, t->tm_sec);
     logmtx.unlock();
 }
 


### PR DESCRIPTION
Changes 

```
[18:49:59] loaded 17M reads
[18:50:9] loaded 18M reads
[18:50:19] loaded 19M reads
```

to

```
[18:49:59] loaded 17M reads
[18:50:09] loaded 18M reads
[18:50:19] loaded 19M reads
```