### PR TITLE
Add support for the Illumina NextSeq 550DX to the two color evaluator.

### DIFF
--- a/src/evaluator.cpp
+++ b/src/evaluator.cpp
@@ -21,8 +21,8 @@ bool Evaluator::isTwoColorSystem() {
     if(!r)
         return false;
 
-    // NEXTSEQ500, NEXTSEQ 550, NOVASEQ
-    if(starts_with(r->mName, "@NS") || starts_with(r->mName, "@NB") || starts_with(r->mName, "@A0")) {
+    // NEXTSEQ500, NEXTSEQ 550/550DX, NOVASEQ
+    if(starts_with(r->mName, "@NS") || starts_with(r->mName, "@NB") || starts_with(r->mName, "@NDX") || starts_with(r->mName, "@A0")) {
         delete r;
         return true;
     }


### PR DESCRIPTION
Adds support for the Illumina NextSeq 550DX to the two color evaluator. Here's a sample FASTQ ID string for the 550DX:

```
@NDX550213:8:HHYV2AFX2:1:11101:14546:1021 1:N:0:0
```