### PR TITLE
Add alternative plotly https src

### DIFF
--- a/src/htmlreporter.cpp
+++ b/src/htmlreporter.cpp
@@ -239,7 +239,7 @@ void HtmlReporter::reportInsertSize(ofstream& ofs, int isizeLimit) {
     ofs << " or &gt;" << isizeLimit;
     ofs << ", or contain too much sequencing errors to be detected as overlapped.";
     ofs <<"</div>\n";
-    
+
     ofs << "\n<script type=\"text/javascript\">" << endl;
     string json_str = "var data=[";
 
@@ -268,7 +268,7 @@ void HtmlReporter::reportDuplication(ofstream& ofs) {
     ofs << "<div id='duplication_figure'>\n";
     ofs << "<div class='figure' id='plot_duplication' style='height:400px;'></div>\n";
     ofs << "</div>\n";
-    
+
     ofs << "\n<script type=\"text/javascript\">" << endl;
     string json_str = "var data=[";
 
@@ -351,7 +351,7 @@ void HtmlReporter::report(FilterResult* result, Stats* preStats1, Stats* postSta
     ofs << "<div class='section_title' onclick=showOrHide('after_filtering')><a name='summary'>After filtering</a></div>\n";
     ofs << "<div id='after_filtering'>\n";
 
-    if(postStats1) {  
+    if(postStats1) {
         string name = "read1";
         if(mOptions->merge.enabled)
             name = "merged";
@@ -407,6 +407,9 @@ void HtmlReporter::printCSS(ofstream& ofs){
 
 void HtmlReporter::printJS(ofstream& ofs){
     ofs << "<script src='http://opengene.org/plotly-1.2.0.min.js'></script>" << endl;
+    ofs << "\n<script type='text/javascript'>" << endl;
+    ofs << "    window.Plotly || document.write('<script src=\"https://cdn.plot.ly/plotly-1.2.0.min.js\"><\/script>')" << endl;
+    ofs << "</script>" << endl;
     ofs << "\n<script type=\"text/javascript\">" << endl;
     ofs << "    function showOrHide(divname) {" << endl;
     ofs << "        div = document.getElementById(divname);" << endl;

--- a/src/htmlreporter.cpp
+++ b/src/htmlreporter.cpp
@@ -408,7 +408,7 @@ void HtmlReporter::printCSS(ofstream& ofs){
 void HtmlReporter::printJS(ofstream& ofs){
     ofs << "<script src='http://opengene.org/plotly-1.2.0.min.js'></script>" << endl;
     ofs << "\n<script type='text/javascript'>" << endl;
-    ofs << "    window.Plotly || document.write('<script src=\"https://cdn.plot.ly/plotly-1.2.0.min.js\"><\/script>')" << endl;
+    ofs << "    window.Plotly || document.write('<script src=\"https://cdn.plot.ly/plotly-1.2.0.min.js\"><\\/script>')" << endl;
     ofs << "</script>" << endl;
     ofs << "\n<script type=\"text/javascript\">" << endl;
     ofs << "    function showOrHide(divname) {" << endl;


### PR DESCRIPTION
There was a problem with fetching plotly.js lib via unsecured http protocol if generated html files are hosted on secured (https) domains. This is a browser restriction and below is chrome 85 console error:

_Mixed Content: The page at 'https://{mydomain.com}/fastap-generated.html' was loaded over HTTPS, but requested an insecure script 'http://opengene.org/plotly-1.2.0.min.js'. This request has been blocked; the content must be served over HTTPS._

This code will generate new script tag with **scr=https://cdn.plot.ly/plotly-1.2.0.min.js** and fetch plotly this way only if plotly lib from **http://opengene.org/plotly-1.2.0.min.js** is not fetched.

