### PR TITLE
Exit with error code after gzip file read fail or throw "ERROR: sequence and quality have different length:". Add reads buffer size parameter.

### DIFF
--- a/src/fastqreader.cpp
+++ b/src/fastqreader.cpp
@@ -206,7 +206,7 @@ Read* FastqReader::read(){
 			cerr << sequence << endl;
 			cerr << strand << endl;
 			cerr << quality << endl;
-			return NULL;
+			exit(-1);
 		}
 		return new Read(name, sequence, strand, quality, mPhred64);
 	}

--- a/src/fastqreader.cpp
+++ b/src/fastqreader.cpp
@@ -37,7 +37,7 @@ void FastqReader::readToBuf() {
 		// exit if the gzip file broken
 		int z_errnum = 0;
 		const char *errmsg = gzerror(mZipFile, &z_errnum);
-		if (z_errnum == Z_BUF_ERROR) {
+		if ((z_errnum == Z_BUF_ERROR) || (z_errnum == Z_ERRNO) || (z_errnum == Z_DATA_ERROR) || (z_errnum == Z_STREAM_ERROR) || (z_errnum == Z_MEM_ERROR)) {
 			cerr << errmsg << endl;
 			exit(-1);
 		}

--- a/src/fastqreader.h
+++ b/src/fastqreader.h
@@ -15,7 +15,7 @@
 
 class FastqReader{
 public:
-	FastqReader(string filename, bool hasQuality = true, bool phred64=false);
+	FastqReader(string filename, bool hasQuality = true, bool phred64=false, size_t fastqBufferSize=1<<20);
 	~FastqReader();
 	bool isZipped();
 
@@ -51,13 +51,14 @@ private:
 	int mBufUsedLen;
 	bool mStdinMode;
 	bool mHasNoLineBreakAtEnd;
+	size_t mFastqBufSize;
 
 };
 
 class FastqReaderPair{
 public:
 	FastqReaderPair(FastqReader* left, FastqReader* right);
-	FastqReaderPair(string leftName, string rightName, bool hasQuality = true, bool phred64 = false, bool interleaved = false);
+	FastqReaderPair(string leftName, string rightName, bool hasQuality = true, bool phred64 = false, bool interleaved = false, size_t fastqBufferSize = 1<<20);
 	~FastqReaderPair();
 	ReadPair* read();
 public:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@ int main(int argc, char* argv[]){
     cmd.add("dont_overwrite", 0, "don't overwrite existing files. Overwritting is allowed by default.");
     cmd.add("fix_mgi_id", 0, "the MGI FASTQ ID format is not compatible with many BAM operation tools, enable this option to fix it.");
     cmd.add("verbose", 'V', "output verbose log information (i.e. when every 1M reads are processed).");
+    cmd.add<int>("reads_buffer", 0, "specify reads buffer size (MB) for each file.", false, 1);
 
     // adapter
     cmd.add("disable_adapter_trimming", 'A', "adapter trimming is enabled by default. If this option is specified, adapter trimming is disabled");
@@ -174,6 +175,10 @@ int main(int argc, char* argv[]){
         opt.unpaired2 = opt.unpaired1;
     opt.compression = cmd.get<int>("compression");
     opt.readsToProcess = cmd.get<int>("reads_to_process");
+    if(cmd.get<int>("reads_buffer") < 1) {
+        error_exit("reads_buffer should be greater or equal to 1MB.");
+    }
+    opt.fastqBufferSize = size_t(cmd.get<int>("reads_buffer")) << 20;
     opt.phred64 = cmd.exist("phred64");
     opt.dontOverwrite = cmd.exist("dont_overwrite");
     opt.inputFromSTDIN = cmd.exist("stdin");

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -27,6 +27,7 @@ Options::Options(){
     seqLen1 = 151;
     seqLen2 = 151;
     fixMGI = false;
+    fastqBufferSize = 1<<20;
 }
 
 void Options::init() {

--- a/src/options.h
+++ b/src/options.h
@@ -331,6 +331,8 @@ public:
     bool fixMGI;
     // worker thread number
     int thread;
+    // fastq reads buffer size
+    size_t fastqBufferSize;
     // trimming options
     TrimmingOptions trim;
     // quality filtering options

--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -709,7 +709,7 @@ void PairEndProcessor::producerTask()
     bool splitSizeReEvaluated = false;
     ReadPair** data = new ReadPair*[PACK_SIZE];
     memset(data, 0, sizeof(ReadPair*)*PACK_SIZE);
-    FastqReaderPair reader(mOptions->in1, mOptions->in2, true, mOptions->phred64, mOptions->interleavedInput);
+    FastqReaderPair reader(mOptions->in1, mOptions->in2, true, mOptions->phred64, mOptions->interleavedInput, mOptions->fastqBufferSize);
     int count=0;
     bool needToBreak = false;
     while(true){

--- a/src/seprocessor.cpp
+++ b/src/seprocessor.cpp
@@ -380,7 +380,7 @@ void SingleEndProcessor::producerTask()
     bool splitSizeReEvaluated = false;
     Read** data = new Read*[PACK_SIZE];
     memset(data, 0, sizeof(Read*)*PACK_SIZE);
-    FastqReader reader(mOptions->in1, true, mOptions->phred64);
+    FastqReader reader(mOptions->in1, true, mOptions->phred64, mOptions->fastqBufferSize);
     int count=0;
     bool needToBreak = false;
     while(true){


### PR DESCRIPTION
#333 

I managed to complete it by myself. Please review it.
And I found it will core dump or segment fault if not exit after gzip file read fail or after throw "ERROR: sequence and quality have different length:" error. Exit with error code (-1) will walk around of these kind of core dump.