### PR TITLE
Changed the typedefs for (u)int64 to (unsigned) long long for mingw

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -5,8 +5,13 @@
 
 #define _DEBUG false
 
-typedef long int64;
-typedef unsigned long uint64;
+#ifndef _WIN32
+	typedef long int64;
+	typedef unsigned long uint64;
+#else
+	typedef long long int64;
+	typedef unsigned long long uint64;
+#endif
 
 typedef int int32;
 typedef unsigned int uint32;


### PR DESCRIPTION
There is a problem when compiling with MinGW64 as specified. 
When running no output is generated due to a an overflow that later causes a division by 0 because in MinGW long is only 32 bits, on Linux it's 64.
