### PR TITLE
Fix compile error on some Linux distros

### DIFF
--- a/src/read.cpp
+++ b/src/read.cpp
@@ -1,5 +1,6 @@
 #include "read.h"
 #include <sstream>
+#include <cstring>
 #include "util.h"
 
 Read::Read(string* name, string* seq, string* strand, string* quality, bool phred64){


### PR DESCRIPTION
Hi,

Compiling fastp from source can fail on AlmaLinux 8.4 (CentOS stable derivative) with the message `error: ‘memcpy’ was not declared in this scope` (see related issue #368 for more details). Adding `#include <cstring>` to src/read.cpp fixes the problem.

Thanks for creating and maintaining a very useful software!