### PR TITLE
Update plotly.js URL to HTTPS

### DIFF
--- a/src/htmlreporter.cpp
+++ b/src/htmlreporter.cpp
@@ -404,7 +404,7 @@ void HtmlReporter::printCSS(ofstream& ofs){
 }
 
 void HtmlReporter::printJS(ofstream& ofs){
-    ofs << "<script src='http://opengene.org/plotly-1.2.0.min.js'></script>" << endl;
+    ofs << "<script src='https://opengene.org/plotly-1.2.0.min.js'></script>" << endl;
     ofs << "\n<script type='text/javascript'>" << endl;
     ofs << "    window.Plotly || document.write('<script src=\"https://cdn.plot.ly/plotly-1.2.0.min.js\"><\\/script>')" << endl;
     ofs << "</script>" << endl;


### PR DESCRIPTION
Resolves issue [#322](https://github.com/OpenGene/fastp/issues/322)
This allows fastp result HTML to display properly over HTTPS.