### PR TITLE
Add option to set the delimiter between the read name and the UMI

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,6 +128,7 @@ int main(int argc, char* argv[]){
     cmd.add<int>("umi_len", 0, "if the UMI is in read1/read2, its length should be provided", false, 0);
     cmd.add<string>("umi_prefix", 0, "if specified, an underline will be used to connect prefix and UMI (i.e. prefix=UMI, UMI=AATTCG, final=UMI_AATTCG). No prefix by default", false, "");
     cmd.add<int>("umi_skip", 0, "if the UMI is in read1/read2, fastp can skip several bases following UMI, default is 0", false, 0);
+    cmd.add<string>("umi_delim", 0, "delimiter to use between the read name and the UMI, default is :", false, ":");
 
     // overrepresented sequence analysis
     cmd.add("overrepresentation_analysis", 'p', "enable overrepresented sequence analysis.");
@@ -376,6 +377,7 @@ int main(int argc, char* argv[]){
     opt.umi.length = cmd.get<int>("umi_len");
     opt.umi.prefix = cmd.get<string>("umi_prefix");
     opt.umi.skip = cmd.get<int>("umi_skip");
+    opt.umi.delimiter = cmd.get<string>("umi_delim");
     if(opt.umi.enabled) {
         string umiLoc = cmd.get<string>("umi_loc");
         str2lower(umiLoc);

--- a/src/options.h
+++ b/src/options.h
@@ -108,6 +108,7 @@ public:
         location = UMI_LOC_NONE;
         length = 0;
         skip = 0;
+        delimiter= ":";
     }
 public:
     bool enabled;
@@ -116,6 +117,7 @@ public:
     int skip;
     string prefix;
     string separator;
+    string delimiter;
 };
 
 class CorrectionOptions {

--- a/src/umiprocessor.cpp
+++ b/src/umiprocessor.cpp
@@ -62,10 +62,11 @@ void UmiProcessor::process(Read* r1, Read* r2) {
 
 void UmiProcessor::addUmiToName(Read* r, string umi){
     string tag;
+    string delimiter = mOptions->umi.delimiter;
     if(mOptions->umi.prefix.empty())
-        tag = ":" + umi;
+        tag = delimiter + umi;
     else
-        tag = ":" + mOptions->umi.prefix + "_" + umi;
+        tag = delimiter + mOptions->umi.prefix + "_" + umi;
     int spacePos = -1;
     for(int i=0; i<r->mName->length(); i++) {
         if(r->mName->at(i) == ' ') {


### PR DESCRIPTION
This allows fastp to match the behaviour of UMI-Tools, which uses (and requires) an underscore between the read name and the UMI.

e.g.
```bash
$ fastp -i R1.fq -o out.R1.fq --umi --umi_loc=read1 --umi_len=8 --umi_delim=_
```

```bash
$ head out.R1.fq
@AS500713:64:HFKJJBGXY:1:11101:17113:1101_TACAAAAT 1:A:0:TATAGCCT+GTTTCTTA
GCACATCGCTGAAAGGGGTAAAGGAGAGAAATCGCTTTATAAAACCTTGAAAAGGAATATTCAAATATAAGCTGGGAAGGTATAAAAAACTCTGTACATCACAAGTAAACAAATGGAACCTGCAAAATATTAAACAAAGGATT
+
EE6EEAAAEEEEE6EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAEEEEAEEEEEEEEEEEEEEEEECFE####EEEE6EE<AAEEEAEEEEEEEEEEEEAEEEEEEEA<E/AAEEEAEEEEE/EEEEAAEEE
@AS500713:64:HFKJJBGXY:1:11101:1675:1101_TAGGAGGC 1:A:0:TATAGCCT+GACCCCCA
TTGGAGTACCAATAATAAAGTGAGCCCACCTTCCTGGTACCCAGACATTTCAGGAGGTCGGGAAATTTTTAAACCCAGGCAGCTTCCTGGCAGTGACATTTGGAGCATCAAAGTGGTAAATAAAATTTCATTTACATTAATAT
+
EEE/E/EA/E/AEA6EE//AEE66/AAE//EEE/E//E/AA/EEE/A/AEE/EEA//EEEEEEEE6EEAAA/E###6E/6//6<EAAEEE/EEEA/EA/EEEEEE/<<EEEE//A/EE<AEEEEE/</AA</E<AAAE/E<E/
@AS500713:64:HFKJJBGXY:1:11101:17113:1101_TACAAAAT 1:A:0:TATAGCCT+GTTTCTTA
```