### PR TITLE
Fix fastp hanging forever on invalid input files

### DIFF
--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -362,6 +362,7 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
         cerr << "Read1 pack size: " << leftPack->count << endl;
         cerr << "Read2 pack size: " << rightPack->count << endl;
         cerr << endl;
+	error_exit("input files don't contain identical amount of reads");
     }
     int tid = config->getThreadId();
 


### PR DESCRIPTION
root cause: the processor does no longer process reads because one of the input files is at EOF while the other still contains reads. When the difference in reads is sufficiently large, the mechanism that pauses a reader when the processor is too far behind kicks in and blocks the reader forever since the processor will no longer process reads.

This will only happen on invalid input. This patch causes fastp to exit with an error when the input is invalid.

* generate an error if zipped input files are truncated
* skipping individual reads with errors causes problems for PE since the reads composing a pair wouldn´t match anymore. Instead, generate an error for obviously incorrectly formatted fastq files.
* generate an error when paired files don´t contain same amount of reads

This fixes issues like  #455, possibly #448, #425, #410, #400, #378, #340 (partial), #333, ...
