### PR TITLE
Typo correction in options.cpp 

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -185,7 +185,7 @@ bool Options::validate() {
     if(!out1.empty()) {
         //check_file_writable(out1);
         if(out1 == out2) {
-            error_exit("read1 output (--out1) and read1 output (--out2) should be different");
+            error_exit("read1 output (--out1) and read2 output (--out2) should be different");
         }
         if(dontOverwrite && file_exists(out1)) {
             error_exit(out1 + " already exists and you have set to not rewrite output files by --dont_overwrite");


### PR DESCRIPTION
While using fastp with PE reads for the first time, I noticed this typo when specifying the same -o and -O output folder. It may seem futile, but this is a good exercise as this would be my first pull request. Hope this is appreciated!