### PR TITLE
Change error message for interleaved stdout

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -160,7 +160,7 @@ bool Options::validate() {
             cerr << "interleaved";
         cerr << " reads to STDOUT..." << endl;
         if(isPaired() && !merge.enabled)
-            cerr << "Enable interleaved output mode for paired-end input." << endl;
+            cerr << "Enable merging output mode for paired-end input." << endl;
         cerr << endl;
     }
 


### PR DESCRIPTION
The message currently refers to "interleaved output mode" but the attribute being checked by the code refers to "merging output mode". I suggest the text should be changed or unless I am missing something, this conditional block should be removed.