### PR TITLE
fix average q-score calculation

### DIFF
--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -2,6 +2,7 @@
 #include "peprocessor.h"
 #include "seprocessor.h"
 #include "overlapanalysis.h"
+#include <cmath>
 
 Filter::Filter(Options* opt){
     mOptions = opt;
@@ -19,7 +20,7 @@ int Filter::passFilter(Read* r) {
     int rlen = r->length();
     int lowQualNum = 0;
     int nBaseNum = 0;
-    int totalQual = 0;
+    float totalQual = 0;
 
     // need to recalculate lowQualNum and nBaseNum if the corresponding filters are enabled
     if(mOptions->qualfilter.enabled || mOptions->lengthFilter.enabled) {
@@ -30,7 +31,7 @@ int Filter::passFilter(Read* r) {
             char base = seqstr[i];
             char qual = qualstr[i];
 
-            totalQual += qual - 33;
+            totalQual += pow(10, ((qual - 33)/(-10.0)));
 
             if(qual < mOptions->qualfilter.qualifiedQual)
                 lowQualNum ++;
@@ -43,7 +44,7 @@ int Filter::passFilter(Read* r) {
     if(mOptions->qualfilter.enabled) {
         if(lowQualNum > (mOptions->qualfilter.unqualifiedPercentLimit * rlen / 100.0) )
             return FAIL_QUALITY;
-        else if(mOptions->qualfilter.avgQualReq > 0 && (totalQual / rlen)<mOptions->qualfilter.avgQualReq)
+        else if(mOptions->qualfilter.avgQualReq > 0 && ((-10)*(log10(totalQual / rlen)))<mOptions->qualfilter.avgQualReq)
             return FAIL_QUALITY;
         else if(nBaseNum > mOptions->qualfilter.nBaseLimit )
             return FAIL_N_BASE;


### PR DESCRIPTION
Hi, big fan of your work! 

In this pull request, I rewrote the --average_qual method to accurately calculate the average quality of a read.

I was running .fastq files of DNA sequenced on our Nanopore through fastp (Nanopore says to use average read q-scores), and way more reads were passing the quality filter than I was used to. I looked into it, and fastp was averaging the q-scores, which are log values, and not taking the q-score out of log scale to p values before averaging. This results in way more reads passing the filter than there should be.

As an example: 
         
         A base with a q-score of 10 and a second base with a q-score of 20, if  
         averaged, would have an average q-score of 15.

         However, if you average the probability of errors: 

         A q-score of 10 is a probability of error of 0.1
         A q-score of 20 is a probability of error of 0.01
         Averaging the probability of error:   0.1 + 0.01 = 0.11  | 0.11 / 2 = 0.055

         The q-score for a probability of error of 0.055 is ~12.5. 
         This number accurately reflects the average amount of error present in the read.

To implement this, in the filter.cpp file, I changed the totalQual variable to a float. I then had the totalQual variable increment by the probability of error instead of the q-score. Then, in the 'else if' statement, I divided the final totalQual value of the read by the rlen, and calculated the resulting q-score to compare to the users input.

I complied the code and tested it on a simulated dataset, and the results were identical to the other nanopore quailty filtering packages I have on my machine.

Thanks again for fastp!!
