### PR TITLE
Fix for 2 bugs in the fastq reader:

### DIFF
--- a/src/fastqreader.h
+++ b/src/fastqreader.h
@@ -65,6 +65,7 @@ private:
 
 private:
 	string mFilename;
+	bool mSkipNewline;
 	struct isal_gzip_header mGzipHeader;
 	struct inflate_state mGzipState;
 	unsigned char *mGzipInputBuffer;


### PR DESCRIPTION
- \r\n handling may cause reading a byte past end of buffer, parser fails
- checking end-of-file condition can only be reliably done after a call to getLine() returns NULL. One particular case is that some gzip files contain empty gzip blocks at the end of the file, which can´t be predicted by the current eof() code Tested with files provided in issue #491.

This reverts commit 0ee1b3b3af1c2c890b063261b2ff55305bb220f0, "fix a regression bug of FASTQ reader"