### PR TITLE
Fix ReadPair's never being freed

### DIFF
--- a/src/fastqreader.cpp
+++ b/src/fastqreader.cpp
@@ -420,16 +420,12 @@ FastqReaderPair::~FastqReaderPair(){
 	}
 }
 
-ReadPair* FastqReaderPair::read(){
+void FastqReaderPair::read(ReadPair* pair){
 	Read* l = mLeft->read();
 	Read* r = NULL;
 	if(mInterleaved)
 		r = mLeft->read();
 	else
 		r = mRight->read();
-	if(!l || !r){
-		return NULL;
-	} else {
-		return new ReadPair(l, r);
-	}
+	pair->setPair(l, r);
 }

--- a/src/fastqreader.h
+++ b/src/fastqreader.h
@@ -91,7 +91,8 @@ public:
 	FastqReaderPair(FastqReader* left, FastqReader* right);
 	FastqReaderPair(string leftName, string rightName, bool hasQuality = true, bool phred64 = false, bool interleaved = false);
 	~FastqReaderPair();
-	ReadPair* read();
+	void read(ReadPair* pair);
+	bool eof();
 public:
 	FastqReader* mLeft;
 	FastqReader* mRight;

--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -681,8 +681,8 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
     if(overlappedOut)
         delete overlappedOut;
 
-    delete leftPack->data;
-    delete rightPack->data;
+    delete[] leftPack->data;
+    delete[] rightPack->data;
     delete leftPack;
     delete rightPack;
 
@@ -870,10 +870,11 @@ void PairEndProcessor::interleavedReaderTask()
     FastqReaderPair reader(mOptions->in1, mOptions->in2, true, mOptions->phred64,true);
     int count=0;
     bool needToBreak = false;
+    ReadPair* pair = new ReadPair();
     while(true){
-        ReadPair* pair = reader.read();
+        reader.read(pair);
         // TODO: put needToBreak here is just a WAR for resolve some unidentified dead lock issue 
-        if(!pair || needToBreak){
+        if(pair->eof() || needToBreak){
             // the last pack
             ReadPack* packLeft = new ReadPack;
             ReadPack* packRight = new ReadPack;
@@ -890,10 +891,6 @@ void PairEndProcessor::interleavedReaderTask()
 
             dataLeft = NULL;
             dataRight = NULL;
-            if(pair) {
-                delete pair;
-                pair = NULL;
-            }
             break;
         }
         dataLeft[count] = pair->mLeft;
@@ -961,6 +958,8 @@ void PairEndProcessor::interleavedReaderTask()
             }*/
         }
     }
+
+    delete pair;
 
     for(int t=0; t<mOptions->thread; t++) {
         mLeftInputLists[t]->setProducerFinished();

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -197,9 +197,9 @@ bool Read::test(){
 	return idx == "GGTCCCGA";
 }
 
-ReadPair::ReadPair(Read* left, Read* right){
-	mLeft = left;
-	mRight = right;
+ReadPair::ReadPair(){
+	mLeft = NULL;
+	mRight = NULL;
 }
 
 ReadPair::~ReadPair(){
@@ -211,6 +211,15 @@ ReadPair::~ReadPair(){
 		delete mRight;
 		mRight = NULL;
 	}
+}
+
+void ReadPair::setPair(Read* left, Read* right){
+	mLeft = left;
+	mRight = right;
+}
+
+bool ReadPair::eof(){
+	return mLeft == NULL || mRight == NULL;
 }
 
 Read* ReadPair::fastMerge(){
@@ -297,7 +306,8 @@ bool ReadPair::test(){
 		new string("+"),
 		new string("AAAAA6EEEEE/EEEEEEEEEEE#EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEAEEEAEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"));
 
-	ReadPair pair(left, right);
+	ReadPair pair;
+	pair.setPair(left, right);
 	Read* merged = pair.fastMerge();
 	if(merged == NULL)
 		return false;

--- a/src/read.h
+++ b/src/read.h
@@ -48,8 +48,10 @@ public:
 
 class ReadPair{
 public:
-    ReadPair(Read* left, Read* right);
+    ReadPair();
     ~ReadPair();
+    void setPair(Read* left, Read* right);
+    bool eof();
 
     // merge a pair, without consideration of seq error caused false INDEL
     Read* fastMerge();


### PR DESCRIPTION
Fixes memory leak in `PairEndProcessor::interleavedReaderTask()` where `ReadPair` objects were not being freed, resulting in a leak of 16 bytes per read pair across the input (Issue #392 ).

Changes:
- Modified call signatures to reuse the same `ReadPair` for all reads, as it's a return container for the Read pairs.
- Added a method to detect the end of input for clarity.
- Updated freeing of the Read arrays to utilize array delete.

**Performance Metrics Comparison on 1KG HG00312 exome with 110M reads**:

| Metric                               | Before   | After    |
|--------------------------------------|----------|----------|
| User time (seconds)                  | 1524.60  | 1507.94  |
| Maximum resident set size (kbytes)   | 4423400  | 2548668  |

All results remained identical.