### PR TITLE
check read errors in fastqreader

### DIFF
--- a/src/fastqreader.h
+++ b/src/fastqreader.h
@@ -46,6 +46,7 @@ public:
 	//do not call read() of a same FastqReader object from different threads concurrently
 	Read* read();
 	bool eof();
+	void check_error();
 	bool hasNoLineBreakAtEnd();
 	void setReadPool(ReadPool* rp);
 


### PR DESCRIPTION
It turns out, if there is a read error while reading a fastq, fastp will loop infinitely.

Per cpp [fread docs](https://cplusplus.com/reference/cstdio/fread/#return), it looks like the caller should check both `feof` and `ferror`. Because `ferror` wasn't checked, fastp went right back to `readToBuf` and looped infinitely.

The issue is really hard to reproduce because you need an unreliable filesystem. While complicated, thankfully I could rerun in our own environment and reliably reproduce, but not in a way I can easily post here.

Anyway, here are the logs I saw after fixing:
```
reading fastq failed: Transport endpoint is not connected
Failed reading: sg_9.fastq
```

And I saw:
```
Command exited with status: exit status: 1
```

So we do see the process actually exit instead of hang.