### PR TITLE
fix incremental build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ ${BIN_TARGET}:${OBJ}
 static:${OBJ}
 	$(CXX) $(OBJ) -o ${BIN_TARGET} $(STATIC_LD_FLAGS)
 
-${DIR_OBJ}/%.o:${DIR_SRC}/%.cpp make_obj_dir
+${DIR_OBJ}/%.o:${DIR_SRC}/%.cpp
+	@mkdir -p $(@D)
 	$(CXX) -c $< -o $@ $(CXXFLAGS)
 
 .PHONY:clean
@@ -41,12 +42,6 @@ clean:
 	@if test -e $(TARGET) ; \
 	then \
 		rm $(TARGET) ; \
-	fi
-
-make_obj_dir:
-	@if test ! -d $(DIR_OBJ) ; \
-	then \
-		mkdir $(DIR_OBJ) ; \
 	fi
 
 install:

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ means that 150bp are from read1, and 15bp are from read2. `fastp` prefers the ba
 Same as the [base correction feature](#base-correction-for-pe-data), this function is also based on overlapping detection, which has adjustable parameters `overlap_len_require (default 30)`, `overlap_diff_limit (default 5)` and `overlap_diff_percent_limit (default 20%)`. Please note that the reads should meet these three conditions simultaneously.
 
 # duplication rate and deduplication
-For both SE and PE data, fastp supports evaluating its duplication rate and removing duplicated reads/pairs. fastp considers one read as duplicated only if its all base pairs are identical as another one. This meas if there is a sequencing error or an N base, the read will not be treated as duplicated.
+For both SE and PE data, fastp supports evaluating its duplication rate and removing duplicated reads/pairs. fastp considers one read as duplicated only if its all base pairs are identical as another one. This means if there is a sequencing error or an N base, the read will not be treated as duplicated.
 
 ## duplication rate evaluation
 By default, fastp evaluates duplication rate, and this module may use 1G memory and take 10% ~ 20% more running time. If you don't need the duplication rate information, you can set `--dont_eval_duplication` to disable the duplication evaluation. But please be noted that, if deduplication (`--dedup`) option is enabled, then `--dont_eval_duplication` option is ignored.

--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -360,7 +360,7 @@ void PairEndProcessor::recycleToPool2(int tid, Read* r) {
 bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, ThreadConfig* config){
     if(leftPack->count != rightPack->count) {
         cerr << endl;
-        cerr << "WARNNIG: different read numbers of the " << mPackProcessedCounter << " pack" << endl;
+        cerr << "WARNING: different read numbers of the " << mPackProcessedCounter << " pack" << endl;
         cerr << "Read1 pack size: " << leftPack->count << endl;
         cerr << "Read2 pack size: " << rightPack->count << endl;
         cerr << endl;


### PR DESCRIPTION
When trying to build this on ubuntu 20.04 in WSL I noticed running `make` would recompile the `.cpp` code every time.

This change makes running `make` multiple much faster since only the files changed will be recompiled.

If you run `make` twice you should see significant build time improvements. This is useful when you change the code, recompile, change the code.