### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: fastp ci
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,11 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
+          - ubuntu-24.04
+          - macos-12
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout scm
@@ -35,6 +36,7 @@ jobs:
         with:
           repository: ebiggers/libdeflate
           path: src/libs/deflate
+          ref: v1.22
 
       - name: build deflate
         run: |
@@ -49,6 +51,7 @@ jobs:
         with:
           repository: intel/isa-l
           path: src/libs/isa-l
+          ref: v2.31.0
 
       - name: build isa-l
         run: |

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ TARGET := fastp
 BIN_TARGET := ${TARGET}
 
 CXX ?= g++
-CXXFLAGS := -std=c++11 -pthread -g -O3 -I${DIR_INC} $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir)) ${CXXFLAGS}
+CXXFLAGS := -std=c++11 -pthread -g -O3 -MD -MP -I${DIR_INC} $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir)) ${CXXFLAGS}
 LIBS := -lisal -ldeflate -lpthread
 STATIC_FLAGS := -static -Wl,--no-as-needed -pthread
 LD_FLAGS := $(foreach librarydir,$(LIBRARY_DIRS),-L$(librarydir)) $(LIBS) $(LD_FLAGS)
@@ -35,15 +35,11 @@ ${DIR_OBJ}/%.o:${DIR_SRC}/%.cpp
 .PHONY:clean
 .PHONY:static
 clean:
-	@if test -d $(DIR_OBJ) ; \
-	then \
-		find $(DIR_OBJ) -name *.o -delete; \
-	fi
-	@if test -e $(TARGET) ; \
-	then \
-		rm $(TARGET) ; \
-	fi
+	@rm -rf $(DIR_OBJ)
+	@rm -f $(TARGET)
 
 install:
 	install $(TARGET) $(BINDIR)/$(TARGET)
 	@echo "Installed."
+
+-include $(OBJ:.o=.d)


### PR DESCRIPTION
Fix the broken CI.
- add `fail-fast: false`. If ci on mac fails, it won't stop building on linux. This is useful to check if one builds but the other doesn't
- Pin the image versions. `macos-latest` automatically updated to `m1` mac on arm64 which was caused the CI to start failing
- Pin the versions of the ubuntu-24.04 so that it doesn't automatically update and randomly fail when a new `latest` is released 
- Fix the ci trigger so that ci is always on pull requests
- Fix the incremental builds header file changes are detected properly.
