### PR TITLE
feat: sets trim-poly-G as True for one-color-system too (iSeq 100)

### DIFF
--- a/src/evaluator.cpp
+++ b/src/evaluator.cpp
@@ -13,7 +13,7 @@ Evaluator::Evaluator(Options* opt){
 Evaluator::~Evaluator(){
 }
 
-bool Evaluator::isTwoColorSystem() {
+bool Evaluator::isOneOrTwoColorSystem() {
     FastqReader reader(mOptions->in1);
 
     Read* r = reader.read();
@@ -21,8 +21,9 @@ bool Evaluator::isTwoColorSystem() {
     if(!r)
         return false;
 
-    // NEXTSEQ500, NEXTSEQ 550/550DX, NOVASEQ
-    if(starts_with(r->mName, "@NS") || starts_with(r->mName, "@NB") || starts_with(r->mName, "@NDX") || starts_with(r->mName, "@A0")) {
+    // NEXTSEQ500, NEXTSEQ 550/550DX, NOVASEQ [2-color-system]
+    // iSeq 100 [1-color-system]
+    if(starts_with(r->mName, "@NS") || starts_with(r->mName, "@NB") || starts_with(r->mName, "@NDX") || starts_with(r->mName, "@A0") | starts_with(r->mName, "@FS100")) {
         delete r;
         return true;
     }

--- a/src/evaluator.h
+++ b/src/evaluator.h
@@ -18,7 +18,7 @@ public:
     void evaluateReadNum(long& readNum);
     string evalAdapterAndReadNumDepreciated(long& readNum);
     string evalAdapterAndReadNum(long& readNum, bool isR2);
-    bool isTwoColorSystem();
+    bool isOneOrTwoColorSystem();
     void evaluateSeqLen();
     void evaluateOverRepSeqs();
     void computeOverRepSeq(string filename, map<string, long>& hotseqs, int seqLen);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -498,8 +498,8 @@ int main(int argc, char* argv[]){
 
     // using evaluator to check if it's two color system
     if(!cmd.exist("trim_poly_g") && !cmd.exist("disable_trim_poly_g") && supportEvaluation) {
-        bool twoColorSystem = eva.isTwoColorSystem();
-        if(twoColorSystem){
+        bool oneOrTwoColorSystem = eva.isOneOrTwoColorSystem();
+        if(oneOrTwoColorSystem){
             opt.polyGTrim.enabled = true;
         }
     }


### PR DESCRIPTION
`fastp` already sets `--trim_poly_g` for two-color-systems (NEXTSEQ500, NEXTSEQ 550/550DX, NOVASEQ), but does not do the same for iSeq, which is a one color system. 

Users of iSeq face the same poly-G issues as those of the other platforms mentioned, so it would make sense to also trim poly-Gs by default.