### PR TITLE
Pull for issue #600 Update peprocessor.cpp: fix duplicate pointer deletion when --overlapped is used.

### DIFF
--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -463,8 +463,8 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
                 overlappedRead->appendToString(overlappedOut);
                 overlappedRead->mName = nullptr;
                 overlappedRead->mStrand = nullptr;
-                recycleToPool1(tid, overlappedRead);
-                overlappedRead = nullptr;
+		delete overlappedRead;
+                //recycleToPool1(tid, overlappedRead);
             }
         }
 

--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -461,7 +461,10 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
             if(ov.overlapped) {
                 Read* overlappedRead = new Read(r1->mName, new string(r1->mSeq->substr(max(0,ov.offset)), ov.overlap_len), r1->mStrand, new string(r1->mQuality->substr(max(0,ov.offset)), ov.overlap_len));
                 overlappedRead->appendToString(overlappedOut);
+                overlappedRead->mName = nullptr;
+                overlappedRead->mStrand = nullptr;
                 recycleToPool1(tid, overlappedRead);
+                overlappedRead = nullptr;
             }
         }
 

--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -463,7 +463,7 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
                 overlappedRead->appendToString(overlappedOut);
                 overlappedRead->mName = nullptr;
                 overlappedRead->mStrand = nullptr;
-		delete overlappedRead;
+                delete overlappedRead;
                 //recycleToPool1(tid, overlappedRead);
             }
         }


### PR DESCRIPTION
Oops didn't realize I could just describe it here... Please see issue #600 

Thanks,
genommm