### PR TITLE
fix duplication accuracy level  calculations logic bug

### DIFF
--- a/src/duplicate.cpp
+++ b/src/duplicate.cpp
@@ -19,7 +19,7 @@ Duplicate::Duplicate(Options* opt) {
     // level 3: 4G
     // level 4: 8G
     // level 5: 16G
-    // level 6: 24G
+    // level 6: 32G
     switch(mOptions->duplicate.accuracyLevel) {
         case 1:
             break;
@@ -40,7 +40,7 @@ Duplicate::Duplicate(Options* opt) {
             break;
         case 6:
             mBufLenInBytes *= 8;
-            mBufNum *= 3;
+            mBufNum *= 4;
             break;
         default:
             break;
@@ -161,7 +161,7 @@ bool Duplicate::applyBloomFilter(uint64* positions) {
 
         //isDup = isDup && (mDupBuf[i * mBufLenInBytes + bytePos] & byte);
         uint8 ret = atomic_fetch_or(mDupBuf + i * mBufLenInBytes + bytePos, byte);
-        isDup = (ret & byte) != 0;
+        isDup &= (ret & byte) != 0;
     }
     return isDup;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]){
 
     // duplication evaluation and deduplication
     cmd.add("dedup", 'D', "enable deduplication to drop the duplicated reads/pairs");
-    cmd.add<int>("dup_calc_accuracy", 0, "accuracy level to calculate duplication (1~6), higher level uses more memory (1G, 2G, 4G, 8G, 16G, 24G). Default 1 for no-dedup mode, and 3 for dedup mode.", false);
+    cmd.add<int>("dup_calc_accuracy", 0, "accuracy level to calculate duplication (1~6), higher level uses more memory (1G, 2G, 4G, 8G, 16G, 32G). Default 1 for no-dedup mode, and 3 for dedup mode.", false);
     cmd.add("dont_eval_duplication", 0, "don't evaluate duplication rate to save time and use less memory.");
 
     // polyG tail trimming


### PR DESCRIPTION
In this PR I made two fixes to the duplicate calculation:

- Fix Bloom membership logic: use AND across all hashes `isDup &= (ret & byte) != 0;` instead of overwriting isDup each iteration `isDup = (ret & byte) != 0;`. The old behavior effectively depended only on the last hash, which could lead to incorrect duplicate results. I have saw this error in my RNA-seq data analysis result.

- Fix non–power-of-two masking at accuracy level 6: at level 6, `mBufNum=6` and `PRIME_ARRAY_LEN * mBufNum` is not a power of two, so `offset &= mask` is not equivalent to modulo and causes biased indexing. I changed level 6 to use `mBufNum=8` (`mBufNum *= 4`), making `PRIME_ARRAY_LEN * mBufNum` a power of two so the existing offset &= mask logic is correct.