### PR TITLE
make interleaved output reproducible again

### DIFF
--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -81,10 +81,10 @@ void PairEndProcessor::initOutput() {
     if(!mOptions->overlappedOut.empty())
         mOverlappedWriter = new WriterThread(mOptions, mOptions->overlappedOut);
 
-    if(mOptions->out1.empty())
+    if(mOptions->out1.empty() && !mOptions->outputToSTDOUT)
         return;
     
-    mLeftWriter = new WriterThread(mOptions, mOptions->out1);
+    mLeftWriter = new WriterThread(mOptions, mOptions->out1, mOptions->outputToSTDOUT);
     if(!mOptions->out2.empty())
         mRightWriter = new WriterThread(mOptions, mOptions->out2);
 }
@@ -599,15 +599,7 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
         }
     }
 
-    if(mOptions->outputToSTDOUT) {
-        // STDOUT output
-        // if it's merging mode, write the merged reads to STDOUT
-        // otherwise write interleaved single output
-        if(mOptions->merge.enabled)
-            fwrite(mergedOutput->c_str(), 1, mergedOutput->length(), stdout);
-        else
-            fwrite(singleOutput->c_str(), 1, singleOutput->length(), stdout);
-    } else if(mOptions->split.enabled) {
+	if(mOptions->split.enabled) {
         // split output by each worker thread
         if(!mOptions->out1.empty()) 
             config->getWriter1()->writeString(outstr1);


### PR DESCRIPTION
fixes issue #654

This same issue was present in 0.24.2 and fixed in 0.24.3 by commit 1d34ed59 .
But later commit 6aa8f09 reverted some of the changes of 1d34ed59 (accidentally I suspect?), and multi-threaded interleaved output was broken again.
This commit restores the working code from 1d34ed59 and fixes the issue in my tests.