### PR TITLE
minor text changes; issue #658 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ sudo make install
 ## input from STDIN
 * specify `--stdin` if you want to read the STDIN for processing.
 * if the STDIN is an interleaved paired-end stream, specify `--interleaved_in` to indicate that.
+* adapter auto-detection is disabled for STDIN mode
 ## store the unpaired reads for PE data
 * you can specify `--unpaired1` to store the reads that read1 passes filters but its paired read2 doesn't, as well as `--unpaired2` for unpaired read2.
 * `--unpaired1` and `--unpaired2` can be the same, so the unpaired read1/read2 will be written to the same single file.
@@ -419,7 +420,7 @@ options:
       --include_unmerged               in the merging mode, write the unmerged or unpaired reads to the file specified by --merge. Disabled by default.
   -6, --phred64                      indicate the input is using phred64 scoring (it'll be converted to phred33, so the output will still be phred33)
   -z, --compression                  compression level for gzip output (1 ~ 9). 1 is fastest, 9 is smallest, default is 4. (int [=4])
-      --stdin                          input from STDIN. If the STDIN is interleaved paired-end FASTQ, please also add --interleaved_in.
+      --stdin                          input from STDIN. If the STDIN is interleaved paired-end FASTQ, please also add --interleaved_in. Adapter auto-detection is disabled for STDIN mode
       --stdout                         output passing-filters reads to STDOUT. This option will result in interleaved FASTQ output for paired-end input. Disabled by default.
       --interleaved_in                 indicate that <in1> is an interleaved FASTQ which contains both read1 and read2. Disabled by default.
       --reads_to_process             specify how many reads/pairs to be processed. Default 0 means process all reads. (int [=0])

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char* argv[]){
     cmd.add("include_unmerged", 0, "in the merging mode, write the unmerged or unpaired reads to the file specified by --merge. Disabled by default.");
     cmd.add("phred64", '6', "indicate the input is using phred64 scoring (it'll be converted to phred33, so the output will still be phred33)");
     cmd.add<int>("compression", 'z', "compression level for gzip output (1 ~ 9). 1 is fastest, 9 is smallest, default is 4.", false, 4);
-    cmd.add("stdin", 0, "input from STDIN. If the STDIN is interleaved paired-end FASTQ, please also add --interleaved_in.");
+    cmd.add("stdin", 0, "input from STDIN. If the STDIN is interleaved paired-end FASTQ, please also add --interleaved_in. Adapter auto-detection is disabled for STDIN mode");
     cmd.add("stdout", 0, "stream passing-filters reads to STDOUT. This option will result in interleaved FASTQ output for paired-end output. Disabled by default.");
     cmd.add("interleaved_in", 0, "indicate that <in1> is an interleaved FASTQ which contains both read1 and read2. Disabled by default.");
     cmd.add<int>("reads_to_process", 0, "specify how many reads/pairs to be processed. Default 0 means process all reads.", false, 0);
@@ -466,9 +466,7 @@ int main(int argc, char* argv[]){
         }
     }
     if(opt.shallDetectAdapter(true)) {
-        if(!supportEvaluation)
-            cerr << "Adapter auto-detection is disabled for STDIN mode" << endl;
-        else {
+        if(supportEvaluation) {
             cerr << "Detecting adapter sequence for read2..." << endl;
             string adapt = eva.evalAdapterAndReadNum(readNum, true);
             if(adapt.length() > 60 )


### PR DESCRIPTION
Added lines in README and docstring  for no auto-detection in case of  STDIN.
This should be a fix for the requested issue #658.

original issue:
"Running fastp from STDIN, whether interleaved paired data with --detect_adapter_for_pe, or on single-end data, runs with no error but outputs messages that auto-detection is disabled (example below). It would be helpful to note this behavior in the README and doc string."

Besides the Added line in the README and the added sentence in the cmd --help docstring, I removed the second Error-output from read2, by checking supportEvaluation instead of !supportEvaluation and an else.

Hope this is clear and helpful.