### PR TITLE
fix: add SumsOf2 fallback for Highway < 1.1.0

### DIFF
--- a/src/simd.cpp
+++ b/src/simd.cpp
@@ -12,6 +12,36 @@ namespace HWY_NAMESPACE {
 
 namespace hn = hwy::HWY_NAMESPACE;
 
+// SumsOf2 pairwise-adds adjacent lanes into the next-wider type
+// (u8 pairs -> u16, u16 pairs -> u32).  Available since Highway 1.1.0;
+// provide a portable fallback for older versions.
+#if !defined(HWY_MAJOR) || HWY_MAJOR < 1 || (HWY_MAJOR == 1 && HWY_MINOR < 1)
+
+template <class V>
+HWY_API hn::VFromD<hn::Repartition<hwy::MakeWide<hn::TFromV<V>>,
+                                     hn::DFromV<V>>>
+SumsOf2Fallback(V v) {
+    using T = hn::TFromV<V>;
+    using TW = hwy::MakeWide<T>;
+    using D = hn::DFromV<V>;
+    using DW = hn::Repartition<TW, D>;
+    const D d;
+    const DW dw;
+    const size_t N = hn::Lanes(d);
+    HWY_ALIGN T buf[hn::MaxLanes(d)];
+    hn::Store(v, d, buf);
+    HWY_ALIGN TW wbuf[hn::MaxLanes(dw)];
+    for (size_t i = 0; i < N / 2; ++i) {
+        wbuf[i] = static_cast<TW>(buf[2 * i]) + static_cast<TW>(buf[2 * i + 1]);
+    }
+    return hn::Load(dw, wbuf);
+}
+#define SumsOf2 SumsOf2Fallback
+
+#else
+using hn::SumsOf2;
+#endif
+
 void CountQualityMetricsImpl(const char* qualstr, const char* seqstr, int len,
                              char qualThreshold, int& lowQualNum, int& nBaseNum,
                              int& totalQual) {


### PR DESCRIPTION
## Summary
- Add compile-time fallback for `SumsOf2` when building against Highway < 1.1.0
- On Highway >= 1.1.0, uses the native `hn::SumsOf2` with zero overhead
- Fallback implements pairwise widen-and-add via store/scalar-add/load, used only in the quality metrics reduction path (not inner-loop hot path)

## Test plan
- [x] Verified `simd.o` compiles cleanly with Highway 1.3.0 (native path)
- [ ] Verify build on a system with Highway < 1.1.0 (e.g. Ubuntu 22.04 apt package)
- [ ] Run `testSimd()` to confirm correctness on both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)