### PR TITLE
perf: processing pipeline optimizations (32% faster PE fq→fq)

### DIFF
--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -112,8 +112,8 @@ Read* Filter::trimAndCut(Read* r, int front, int tail, int& frontTrimmed) {
             if(s > front) {
                 totalQual -= qualstr[s-1];
             }
-            // add 33 for phred33 transforming
-            if((double)totalQual / (double)w >= 33 + mOptions->qualityCut.qualityFront)
+            // add 33 for phred33 transforming (integer multiply instead of FP divide)
+            if(totalQual >= w * (33 + mOptions->qualityCut.qualityFront))
                 break;
         }
 
@@ -147,8 +147,8 @@ Read* Filter::trimAndCut(Read* r, int front, int tail, int& frontTrimmed) {
             if(s > front) {
                 totalQual -= qualstr[s-1];
             }
-            // add 33 for phred33 transforming
-            if((double)totalQual / (double)w < 33 + mOptions->qualityCut.qualityRight) {
+            // add 33 for phred33 transforming (integer multiply instead of FP divide)
+            if(totalQual < w * (33 + mOptions->qualityCut.qualityRight)) {
                 foundLowQualWindow = true;
                 break;
             }
@@ -181,8 +181,8 @@ Read* Filter::trimAndCut(Read* r, int front, int tail, int& frontTrimmed) {
             if(t < l-tail-1) {
                 totalQual -= qualstr[t+1];
             }
-            // add 33 for phred33 transforming
-            if((double)totalQual / (double)w >= 33 + mOptions->qualityCut.qualityTail)
+            // add 33 for phred33 transforming (integer multiply instead of FP divide)
+            if(totalQual >= w * (33 + mOptions->qualityCut.qualityTail))
                 break;
         }
 

--- a/src/overlapanalysis.cpp
+++ b/src/overlapanalysis.cpp
@@ -15,9 +15,12 @@ OverlapResult OverlapAnalysis::analyze(Read* r1, Read* r2, int overlapDiffLimit,
 
 // ported from the python code of AfterQC
 OverlapResult OverlapAnalysis::analyze(string*  r1, string*  r2, int diffLimit, int overlapRequire, double diffPercentLimit, bool allowGap) {
-    string rcr2 = Sequence::reverseComplement(r2);
+    // Reuse thread_local buffer to avoid per-call allocation
+    thread_local string rcr2;
+    int len2 = r2->length();
+    rcr2.resize(len2);
+    fastp_simd::reverseComplement(r2->c_str(), &rcr2[0], len2);
     int len1 = r1->length();
-    int len2 = rcr2.length();
     // use the pointer directly for speed
     const char* str1 = r1->c_str();
     const char* str2 = rcr2.c_str();

--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -430,19 +430,31 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
         }
         bool isizeEvaluated = false;
         bool isAdapterDimer = false;
+
+        // Cache overlap result: compute once, reuse for adapter trimming, correction, isize, and merge
+        OverlapResult ov = {};
+        bool ovComputed = false;
+        if(r1 != NULL && r2!=NULL && (mOptions->adapter.enabled || mOptions->correction.enabled || config->getThreadId() == 0 || mOptions->merge.enabled)){
+            ov = OverlapAnalysis::analyze(r1, r2, mOptions->overlapDiffLimit, mOptions->overlapRequire, mOptions->overlapDiffPercentLimit/100.0);
+            ovComputed = true;
+        }
+
         if(r1 != NULL && r2!=NULL && (mOptions->adapter.enabled || mOptions->correction.enabled)){
-            OverlapResult ov = OverlapAnalysis::analyze(r1, r2, mOptions->overlapDiffLimit, mOptions->overlapRequire, mOptions->overlapDiffPercentLimit/100.0, mOptions->adapter.allowGapOverlapTrimming);
-            // we only use thread 0 to evaluae ISIZE
+            // For gap-aware adapter trimming, compute a separate overlap if needed
+            OverlapResult ovForAdapter = mOptions->adapter.allowGapOverlapTrimming
+                ? OverlapAnalysis::analyze(r1, r2, mOptions->overlapDiffLimit, mOptions->overlapRequire, mOptions->overlapDiffPercentLimit/100.0, true)
+                : ov;
+            // we only use thread 0 to evaluate ISIZE
             if(config->getThreadId() == 0) {
                 statInsertSize(r1, r2, ov, frontTrimmed1, frontTrimmed2);
                 isizeEvaluated = true;
             }
-            if(mOptions->correction.enabled && !ov.hasGap) {
+            if(mOptions->correction.enabled && !ovForAdapter.hasGap) {
                 // no gap allowed for overlap correction
-                BaseCorrector::correctByOverlapAnalysis(r1, r2, config->getFilterResult(), ov);
+                BaseCorrector::correctByOverlapAnalysis(r1, r2, config->getFilterResult(), ovForAdapter);
             }
             if(mOptions->adapter.enabled) {
-                bool trimmed = AdapterTrimmer::trimByOverlapAnalysis(r1, r2, config->getFilterResult(), ov, frontTrimmed1, frontTrimmed2);
+                bool trimmed = AdapterTrimmer::trimByOverlapAnalysis(r1, r2, config->getFilterResult(), ovForAdapter, frontTrimmed1, frontTrimmed2);
                 bool trimmed1 = trimmed;
                 bool trimmed2 = trimmed;
                 if(!trimmed){
@@ -467,16 +479,19 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
         }
 
         if(r1 != NULL && r2!=NULL && mOverlappedWriter) {
-            OverlapResult ov = OverlapAnalysis::analyze(r1, r2, mOptions->overlapDiffLimit, mOptions->overlapRequire, 0);
-            if(ov.overlapped) {
-                Read* overlappedRead = new Read(new string(*r1->mName), new string(r1->mSeq->substr(max(0,ov.offset)), ov.overlap_len), new string(*r1->mStrand), new string(r1->mQuality->substr(max(0,ov.offset)), ov.overlap_len));
+            OverlapResult ovForOverlapped = OverlapAnalysis::analyze(r1, r2, mOptions->overlapDiffLimit, mOptions->overlapRequire, 0);
+            if(ovForOverlapped.overlapped) {
+                Read* overlappedRead = new Read(new string(*r1->mName), new string(r1->mSeq->substr(max(0,ovForOverlapped.offset)), ovForOverlapped.overlap_len), new string(*r1->mStrand), new string(r1->mQuality->substr(max(0,ovForOverlapped.offset)), ovForOverlapped.overlap_len));
                 overlappedRead->appendToString(&overlappedOut);
                 recycleToPool1(tid, overlappedRead);
             }
         }
 
         if(config->getThreadId() == 0 && !isizeEvaluated && r1 != NULL && r2!=NULL) {
-            OverlapResult ov = OverlapAnalysis::analyze(r1, r2, mOptions->overlapDiffLimit, mOptions->overlapRequire, mOptions->overlapDiffPercentLimit/100.0);
+            if(!ovComputed) {
+                ov = OverlapAnalysis::analyze(r1, r2, mOptions->overlapDiffLimit, mOptions->overlapRequire, mOptions->overlapDiffPercentLimit/100.0);
+                ovComputed = true;
+            }
             statInsertSize(r1, r2, ov, frontTrimmed1, frontTrimmed2);
             isizeEvaluated = true;
         }
@@ -497,7 +512,10 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
         // merging mode
         bool mergeProcessed = false;
         if(mOptions->merge.enabled && r1 && r2) {
-            OverlapResult ov = OverlapAnalysis::analyze(r1, r2, mOptions->overlapDiffLimit, mOptions->overlapRequire, mOptions->overlapDiffPercentLimit/100.0);
+            if(!ovComputed) {
+                ov = OverlapAnalysis::analyze(r1, r2, mOptions->overlapDiffLimit, mOptions->overlapRequire, mOptions->overlapDiffPercentLimit/100.0);
+                ovComputed = true;
+            }
             if(ov.overlapped) {
                 merged = OverlapAnalysis::merge(r1, r2, ov);
                 int result = mFilter->passFilter(merged);

--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <functional>
 #include <thread>
+#include <chrono>
 #include <memory.h>
 #include "util.h"
 #include "adaptertrimmer.h"
@@ -690,11 +691,12 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
     delete leftPack;
     delete rightPack;
 
-    mPackProcessedCounter++;
+    mPackProcessedCounter.fetch_add(1, std::memory_order_release);
+    mBackpressureCV.notify_all();
 
     return true;
 }
-    
+
 void PairEndProcessor::statInsertSize(Read* r1, Read* r2, OverlapResult& ov, int frontTrimmed1, int frontTrimmed2) {
     int isize = mOptions->insertSizeMax;
     if(ov.overlapped) {
@@ -753,6 +755,7 @@ void PairEndProcessor::readerTask(bool isLeft)
                 mRightInputLists[mRightPackReadCounter % mOptions->thread]->produce(pack);
                 mRightPackReadCounter++;
             }
+            mBackpressureCV.notify_all();
             data = NULL;
             if(read) {
                 delete read;
@@ -789,31 +792,34 @@ void PairEndProcessor::readerTask(bool isLeft)
                 mRightInputLists[mRightPackReadCounter % mOptions->thread]->produce(pack);
                 mRightPackReadCounter++;
             }
+            mBackpressureCV.notify_all();
 
             //re-initialize data for next pack
             data = new Read*[PACK_SIZE];
             memset(data, 0, sizeof(Read*)*PACK_SIZE);
             // if the processor is far behind this reader, sleep and wait to limit memory usage
-            if(isLeft) {
-                while(mLeftPackReadCounter - mPackProcessedCounter > PACK_IN_MEM_LIMIT){
-                    //cerr<<"sleep"<<endl;
-                    slept++;
-                    usleep(100);
-                }
-            } else {
-                while(mRightPackReadCounter - mPackProcessedCounter > PACK_IN_MEM_LIMIT){
-                    //cerr<<"sleep"<<endl;
-                    slept++;
-                    usleep(100);
+            {
+                std::unique_lock<std::mutex> lk(mBackpressureMtx);
+                if(isLeft) {
+                    while(mLeftPackReadCounter - mPackProcessedCounter.load(std::memory_order_acquire) > PACK_IN_MEM_LIMIT){
+                        slept++;
+                        mBackpressureCV.wait_for(lk, std::chrono::milliseconds(1));
+                    }
+                } else {
+                    while(mRightPackReadCounter - mPackProcessedCounter.load(std::memory_order_acquire) > PACK_IN_MEM_LIMIT){
+                        slept++;
+                        mBackpressureCV.wait_for(lk, std::chrono::milliseconds(1));
+                    }
                 }
             }
             readNum += count;
             // if the writer threads are far behind this producer, sleep and wait
             // check this only when necessary
             if(readNum % (PACK_SIZE * PACK_IN_MEM_LIMIT) == 0 && mLeftWriter) {
+                std::unique_lock<std::mutex> lk(mBackpressureMtx);
                 while( (mLeftWriter && mLeftWriter->bufferLength() > PACK_IN_MEM_LIMIT) || (mRightWriter && mRightWriter->bufferLength() > PACK_IN_MEM_LIMIT) ){
                     slept++;
-                    usleep(1000);
+                    mBackpressureCV.wait_for(lk, std::chrono::milliseconds(1));
                 }
             }
             // reset count to 0
@@ -841,14 +847,15 @@ void PairEndProcessor::readerTask(bool isLeft)
         else
             mRightInputLists[t]->setProducerFinished();
     }
+    mBackpressureCV.notify_all();
 
     if(mOptions->verbose) {
         if(isLeft) {
-            mLeftReaderFinished = true;
+            mLeftReaderFinished.store(true, std::memory_order_release);
             loginfo("Read1: loading completed with " + to_string(mLeftPackReadCounter) + " packs");
         }
         else {
-            mRightReaderFinished = true;
+            mRightReaderFinished.store(true, std::memory_order_release);
             loginfo("Read2: loading completed with " + to_string(mRightPackReadCounter) + " packs");
         }
     }
@@ -895,6 +902,7 @@ void PairEndProcessor::interleavedReaderTask()
             mRightInputLists[mRightPackReadCounter % mOptions->thread]->produce(packRight);
             mRightPackReadCounter++;
 
+            mBackpressureCV.notify_all();
             dataLeft = NULL;
             dataRight = NULL;
             break;
@@ -925,6 +933,7 @@ void PairEndProcessor::interleavedReaderTask()
 
             mRightInputLists[mRightPackReadCounter % mOptions->thread]->produce(packRight);
             mRightPackReadCounter++;
+            mBackpressureCV.notify_all();
 
             //re-initialize data for next pack
             dataLeft = new Read*[PACK_SIZE];
@@ -932,18 +941,21 @@ void PairEndProcessor::interleavedReaderTask()
             memset(dataLeft, 0, sizeof(Read*)*PACK_SIZE);
             memset(dataRight, 0, sizeof(Read*)*PACK_SIZE);
             // if the consumer is far behind this producer, sleep and wait to limit memory usage
-            while(mLeftPackReadCounter - mPackProcessedCounter > PACK_IN_MEM_LIMIT){
-                //cerr<<"sleep"<<endl;
-                slept++;
-                usleep(100);
+            {
+                std::unique_lock<std::mutex> lk(mBackpressureMtx);
+                while(mLeftPackReadCounter - mPackProcessedCounter.load(std::memory_order_acquire) > PACK_IN_MEM_LIMIT){
+                    slept++;
+                    mBackpressureCV.wait_for(lk, std::chrono::milliseconds(1));
+                }
             }
             readNum += count;
             // if the writer threads are far behind this producer, sleep and wait
             // check this only when necessary
             if(readNum % (PACK_SIZE * PACK_IN_MEM_LIMIT) == 0 && mLeftWriter) {
+                std::unique_lock<std::mutex> lk(mBackpressureMtx);
                 while( (mLeftWriter && mLeftWriter->bufferLength() > PACK_IN_MEM_LIMIT) || (mRightWriter && mRightWriter->bufferLength() > PACK_IN_MEM_LIMIT) ){
                     slept++;
-                    usleep(1000);
+                    mBackpressureCV.wait_for(lk, std::chrono::milliseconds(1));
                 }
             }
             // reset count to 0
@@ -971,13 +983,14 @@ void PairEndProcessor::interleavedReaderTask()
         mLeftInputLists[t]->setProducerFinished();
         mRightInputLists[t]->setProducerFinished();
     }
+    mBackpressureCV.notify_all();
 
     if(mOptions->verbose) {
         loginfo("interleaved: loading completed with " + to_string(mLeftPackReadCounter) + " packs");
     }
 
-    mLeftReaderFinished = true;
-    mRightReaderFinished = true;
+    mLeftReaderFinished.store(true, std::memory_order_release);
+    mRightReaderFinished.store(true, std::memory_order_release);
 
     // if the last data initialized is not used, free it
     if(dataLeft != NULL)
@@ -1004,19 +1017,20 @@ void PairEndProcessor::processorTask(ThreadConfig* config)
         } else if(inputRight->isProducerFinished() && !inputRight->canBeConsumed()) {
             break;
         } else {
-            usleep(100);
+            std::unique_lock<std::mutex> lk(mBackpressureMtx);
+            mBackpressureCV.wait_for(lk, std::chrono::milliseconds(1));
         }
     }
     inputLeft->setConsumerFinished();
     inputRight->setConsumerFinished();
 
-    mFinishedThreads++;
+    int finishedCount = mFinishedThreads.fetch_add(1, std::memory_order_release) + 1;
     if(mOptions->verbose) {
         string msg = "thread " + to_string(config->getThreadId() + 1) + " data processing completed";
         loginfo(msg);
     }
 
-    if(mFinishedThreads == mOptions->thread) {
+    if(finishedCount == mOptions->thread) {
         if(mLeftWriter)
             mLeftWriter->setInputCompleted();
         if(mRightWriter)

--- a/src/peprocessor.h
+++ b/src/peprocessor.h
@@ -46,7 +46,7 @@ private:
 private:
     atomic_bool mLeftReaderFinished;
     atomic_bool mRightReaderFinished;
-    atomic_int mFinishedThreads;
+    alignas(128) atomic_int mFinishedThreads;
     Options* mOptions;
     Filter* mFilter;
     UmiProcessor* mUmiProcessor;
@@ -63,7 +63,7 @@ private:
     SingleProducerSingleConsumerList<ReadPack*>** mRightInputLists;
     size_t mLeftPackReadCounter;
     size_t mRightPackReadCounter;
-    atomic_long mPackProcessedCounter;
+    alignas(128) atomic_long mPackProcessedCounter;
     ReadPool* mLeftReadPool;
     ReadPool* mRightReadPool;
     atomic_bool shouldStopReading;

--- a/src/peprocessor.h
+++ b/src/peprocessor.h
@@ -67,6 +67,8 @@ private:
     ReadPool* mLeftReadPool;
     ReadPool* mRightReadPool;
     atomic_bool shouldStopReading;
+    std::mutex mBackpressureMtx;
+    std::condition_variable mBackpressureCV;
 };
 
 

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -117,32 +117,40 @@ string Read::toString() {
 }
 
 void Read::appendToString(string* target) {
-	size_t size = mName->length() + mSeq->length() + mStrand->length() + mQuality->length() + 4;
-	target->reserve(target->size() + size);
-	target->append(*mName);
-	target->push_back('\n');
-	target->append(*mSeq);
-	target->push_back('\n');
-	target->append(*mStrand);
-	target->push_back('\n');
-	target->append(*mQuality);
-	target->push_back('\n');
+	size_t nameLen = mName->length();
+	size_t seqLen = mSeq->length();
+	size_t strandLen = mStrand->length();
+	size_t qualLen = mQuality->length();
+	size_t totalSize = nameLen + seqLen + strandLen + qualLen + 4;
+
+	size_t oldSize = target->size();
+	target->resize(oldSize + totalSize);
+	char* dst = &(*target)[oldSize];
+
+	memcpy(dst, mName->data(), nameLen); dst += nameLen; *dst++ = '\n';
+	memcpy(dst, mSeq->data(), seqLen); dst += seqLen; *dst++ = '\n';
+	memcpy(dst, mStrand->data(), strandLen); dst += strandLen; *dst++ = '\n';
+	memcpy(dst, mQuality->data(), qualLen); dst += qualLen; *dst++ = '\n';
 }
 
 void Read::appendToStringWithTag(string* target, const char* tag) {
+	size_t nameLen = mName->length();
 	size_t tagLen = strlen(tag);
-	size_t size = mName->length() + 1 + tagLen + mSeq->length() + mStrand->length() + mQuality->length() + 4;
-	target->reserve(target->size() + size);
-	target->append(*mName);
-	target->push_back(' ');
-	target->append(tag, tagLen);
-	target->push_back('\n');
-	target->append(*mSeq);
-	target->push_back('\n');
-	target->append(*mStrand);
-	target->push_back('\n');
-	target->append(*mQuality);
-	target->push_back('\n');
+	size_t seqLen = mSeq->length();
+	size_t strandLen = mStrand->length();
+	size_t qualLen = mQuality->length();
+	size_t totalSize = nameLen + 1 + tagLen + seqLen + strandLen + qualLen + 4;
+
+	size_t oldSize = target->size();
+	target->resize(oldSize + totalSize);
+	char* dst = &(*target)[oldSize];
+
+	memcpy(dst, mName->data(), nameLen); dst += nameLen;
+	*dst++ = ' ';
+	memcpy(dst, tag, tagLen); dst += tagLen; *dst++ = '\n';
+	memcpy(dst, mSeq->data(), seqLen); dst += seqLen; *dst++ = '\n';
+	memcpy(dst, mStrand->data(), strandLen); dst += strandLen; *dst++ = '\n';
+	memcpy(dst, mQuality->data(), qualLen); dst += qualLen; *dst++ = '\n';
 }
 
 string Read::toStringWithTag(const char* tag) {

--- a/src/read.cpp
+++ b/src/read.cpp
@@ -129,12 +129,13 @@ void Read::appendToString(string* target) {
 	target->push_back('\n');
 }
 
-void Read::appendToStringWithTag(string* target, string tag) {
-	size_t size = mName->length() + 1 + tag.length() + mSeq->length() + mStrand->length() + mQuality->length() + 4;
+void Read::appendToStringWithTag(string* target, const char* tag) {
+	size_t tagLen = strlen(tag);
+	size_t size = mName->length() + 1 + tagLen + mSeq->length() + mStrand->length() + mQuality->length() + 4;
 	target->reserve(target->size() + size);
 	target->append(*mName);
 	target->push_back(' ');
-	target->append(tag);
+	target->append(tag, tagLen);
 	target->push_back('\n');
 	target->append(*mSeq);
 	target->push_back('\n');
@@ -144,7 +145,7 @@ void Read::appendToStringWithTag(string* target, string tag) {
 	target->push_back('\n');
 }
 
-string Read::toStringWithTag(string tag) {
+string Read::toStringWithTag(const char* tag) {
 	return *mName + " " + tag + "\n" + *mSeq + "\n" + *mStrand + "\n" + *mQuality + "\n";
 }
 

--- a/src/read.h
+++ b/src/read.h
@@ -25,9 +25,9 @@ public:
     int lowQualCount(int qual=20);
     int length();
     string toString();
-    string toStringWithTag(string tag);
+    string toStringWithTag(const char* tag);
     void appendToString(string* target);
-    void appendToStringWithTag(string* target, string tag);
+    void appendToStringWithTag(string* target, const char* tag);
     void resize(int len);
     void convertPhred64To33();
     void trimFront(int len);

--- a/src/seprocessor.cpp
+++ b/src/seprocessor.cpp
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include <functional>
 #include <thread>
+#include <chrono>
 #include <memory.h>
 #include "util.h"
 #include "jsonreporter.h"
@@ -315,7 +316,8 @@ bool SingleEndProcessor::processSingleEnd(ReadPack* pack, ThreadConfig* config){
     delete pack->data;
     delete pack;
 
-    mPackProcessedCounter++;
+    mPackProcessedCounter.fetch_add(1, std::memory_order_release);
+    mBackpressureCV.notify_all();
 
     return true;
 }
@@ -343,6 +345,7 @@ void SingleEndProcessor::readerTask()
             pack->count = count;
             mInputLists[mPackReadCounter % mOptions->thread]->produce(pack);
             mPackReadCounter++;
+            mBackpressureCV.notify_all();
             data = NULL;
             if(read) {
                 delete read;
@@ -368,22 +371,26 @@ void SingleEndProcessor::readerTask()
             pack->count = count;
             mInputLists[mPackReadCounter % mOptions->thread]->produce(pack);
             mPackReadCounter++;
+            mBackpressureCV.notify_all();
             //re-initialize data for next pack
             data = new Read*[PACK_SIZE];
             memset(data, 0, sizeof(Read*)*PACK_SIZE);
             // if the processor is far behind this reader, sleep and wait to limit memory usage
-            while( mPackReadCounter - mPackProcessedCounter > PACK_IN_MEM_LIMIT){
-                //cerr<<"sleep"<<endl;
-                slept++;
-                usleep(100);
+            {
+                std::unique_lock<std::mutex> lk(mBackpressureMtx);
+                while( mPackReadCounter - mPackProcessedCounter.load(std::memory_order_acquire) > PACK_IN_MEM_LIMIT){
+                    slept++;
+                    mBackpressureCV.wait_for(lk, std::chrono::milliseconds(1));
+                }
             }
             readNum += count;
             // if the writer threads are far behind this reader, sleep and wait
             // check this only when necessary
             if(readNum % (PACK_SIZE * PACK_IN_MEM_LIMIT) == 0 && mLeftWriter) {
+                std::unique_lock<std::mutex> lk(mBackpressureMtx);
                 while(mLeftWriter->bufferLength() > PACK_IN_MEM_LIMIT) {
                     slept++;
-                    usleep(1000);
+                    mBackpressureCV.wait_for(lk, std::chrono::milliseconds(1));
                 }
             }
             // reset count to 0
@@ -409,7 +416,7 @@ void SingleEndProcessor::readerTask()
         mInputLists[t]->setProducerFinished();
 
     //std::unique_lock<std::mutex> lock(mRepo.readCounterMtx);
-    mReaderFinished = true;
+    mReaderFinished.store(true, std::memory_order_release);
     if(mOptions->verbose) {
         loginfo("Loading completed with " + to_string(mPackReadCounter) + " packs");
     }
@@ -440,13 +447,13 @@ void SingleEndProcessor::processorTask(ThreadConfig* config)
                 break;
             }
         } else {
-            usleep(100);
+            std::unique_lock<std::mutex> lk(mBackpressureMtx);
+            mBackpressureCV.wait_for(lk, std::chrono::milliseconds(1));
         }
     }
     input->setConsumerFinished();
 
-    mFinishedThreads++;
-    if(mFinishedThreads == mOptions->thread) {
+    if(mFinishedThreads.fetch_add(1, std::memory_order_release) + 1 == mOptions->thread) {
         if(mLeftWriter)
             mLeftWriter->setInputCompleted();
         if(mFailedWriter)

--- a/src/seprocessor.h
+++ b/src/seprocessor.h
@@ -51,6 +51,8 @@ private:
     size_t mPackReadCounter;
     alignas(128) atomic_long mPackProcessedCounter;
     ReadPool* mReadPool;
+    std::mutex mBackpressureMtx;
+    std::condition_variable mBackpressureCV;
 };
 
 

--- a/src/seprocessor.h
+++ b/src/seprocessor.h
@@ -41,7 +41,7 @@ private:
 private:
     Options* mOptions;
     atomic_bool mReaderFinished;
-    atomic_int mFinishedThreads;
+    alignas(128) atomic_int mFinishedThreads;
     Filter* mFilter;
     UmiProcessor* mUmiProcessor;
     WriterThread* mLeftWriter;
@@ -49,7 +49,7 @@ private:
     Duplicate* mDuplicate;
     SingleProducerSingleConsumerList<ReadPack*>** mInputLists;
     size_t mPackReadCounter;
-    atomic_long mPackProcessedCounter;
+    alignas(128) atomic_long mPackProcessedCounter;
     ReadPool* mReadPool;
 };
 

--- a/src/simd.cpp
+++ b/src/simd.cpp
@@ -12,6 +12,45 @@ namespace HWY_NAMESPACE {
 
 namespace hn = hwy::HWY_NAMESPACE;
 
+// --- Highway version compatibility shims ---
+// SumsOf2: pairwise widen-and-add (u8→u16, u16→u32). Added in Highway 1.1.0.
+#if !defined(HWY_MAJOR) || HWY_MAJOR < 1 || (HWY_MAJOR == 1 && HWY_MINOR < 1)
+template <class V>
+HWY_API hn::VFromD<hn::Repartition<hwy::MakeWide<hn::TFromV<V>>, hn::DFromV<V>>>
+SumsOf2Fallback(V v) {
+    using T = hn::TFromV<V>;
+    using TW = hwy::MakeWide<T>;
+    using D = hn::DFromV<V>;
+    using DW = hn::Repartition<TW, D>;
+    const D d;
+    const DW dw;
+    const size_t N = hn::Lanes(d);
+    HWY_ALIGN T buf[hn::MaxLanes(d)];
+    hn::Store(v, d, buf);
+    HWY_ALIGN TW wbuf[hn::MaxLanes(dw)];
+    for (size_t i = 0; i < N / 2; ++i) {
+        wbuf[i] = static_cast<TW>(buf[2 * i]) + static_cast<TW>(buf[2 * i + 1]);
+    }
+    return hn::Load(dw, wbuf);
+}
+#define SumsOf2 SumsOf2Fallback
+#else
+using hn::SumsOf2;
+#endif
+
+// ReduceSum: horizontal sum of all lanes to scalar. Added in Highway 1.0.5.
+#if !defined(HWY_MAJOR) || (HWY_MAJOR == 0) || \
+    (HWY_MAJOR == 1 && HWY_MINOR == 0 && (!defined(HWY_PATCH) || HWY_PATCH < 5))
+template <class D, class V>
+HWY_API hn::TFromD<D> ReduceSumFallback(D d, V v) {
+    return hn::GetLane(hn::SumOfLanes(d, v));
+}
+#define ReduceSum ReduceSumFallback
+#else
+using hn::ReduceSum;
+#endif
+// --- End compatibility shims ---
+
 void CountQualityMetricsImpl(const char* qualstr, const char* seqstr, int len,
                              char qualThreshold, int& lowQualNum, int& nBaseNum,
                              int& totalQual) {
@@ -57,13 +96,13 @@ void CountQualityMetricsImpl(const char* qualstr, const char* seqstr, int len,
             // Subtract 33 and accumulate quality into u16 accumulator.
             // SumsOf2 adds adjacent u8 pairs -> u16, works on all targets.
             const auto vQualAdj = hn::Sub(vQual, v33);
-            vQualSum16 = hn::Add(vQualSum16, hn::SumsOf2(vQualAdj));
+            vQualSum16 = hn::Add(vQualSum16, SumsOf2(vQualAdj));
         }
 
         // Reduce u16 accumulator to scalar via SumsOf2 -> u32 then ReduceSum
         const hn::ScalableTag<uint32_t> d32;
         qualSum += static_cast<int>(
-            hn::ReduceSum(d32, hn::SumsOf2(vQualSum16)));
+            ReduceSum(d32, SumsOf2(vQualSum16)));
     }
 
     // Scalar tail

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -931,39 +931,54 @@ Stats* Stats::merge(vector<Stats*>& list) {
     // init overrepresented seq maps
     map<string, long>::iterator iter;
 
+    // merge read number and length sum
     for(int t=0; t<list.size(); t++) {
-        int curCycles =  list[t]->getCycles();
-        // merge read number
         s->mReads += list[t]->mReads;
         s->mLengthSum += list[t]->mLengthSum;
+    }
 
-        // merge per cycle counting for different bases
-        for(int i=0; i<8; i++){
-            for(int j=0; j<cycles && j<curCycles; j++) {
-                s->mCycleQ30Bases[i][j] += list[t]->mCycleQ30Bases[i][j];
-                s->mCycleQ20Bases[i][j] += list[t]->mCycleQ20Bases[i][j];
-                s->mCycleBaseContents[i][j] += list[t]->mCycleBaseContents[i][j];
-                s->mCycleBaseQual[i][j] += list[t]->mCycleBaseQual[i][j];
+    // merge per cycle counting for different bases
+    // Loop reordered to i->j->t for better temporal locality:
+    // keeps destination s->mCycle*[i][j] in register across the inner t loop
+    for(int i=0; i<8; i++){
+        for(int j=0; j<cycles; j++) {
+            for(int t=0; t<list.size(); t++) {
+                if(j < list[t]->getCycles()) {
+                    s->mCycleQ30Bases[i][j] += list[t]->mCycleQ30Bases[i][j];
+                    s->mCycleQ20Bases[i][j] += list[t]->mCycleQ20Bases[i][j];
+                    s->mCycleBaseContents[i][j] += list[t]->mCycleBaseContents[i][j];
+                    s->mCycleBaseQual[i][j] += list[t]->mCycleBaseQual[i][j];
+                }
             }
         }
+    }
 
-        // merge per cycle counting for all bases
-        for(int j=0; j<cycles && j<curCycles; j++) {
-            s->mCycleTotalBase[j] += list[t]->mCycleTotalBase[j];
-            s->mCycleTotalQual[j] += list[t]->mCycleTotalQual[j];
+    // merge per cycle counting for all bases (j->t order)
+    for(int j=0; j<cycles; j++) {
+        for(int t=0; t<list.size(); t++) {
+            if(j < list[t]->getCycles()) {
+                s->mCycleTotalBase[j] += list[t]->mCycleTotalBase[j];
+                s->mCycleTotalQual[j] += list[t]->mCycleTotalQual[j];
+            }
         }
+    }
 
-        // merge kMer
-        for(int i=0; i<s->mKmerBufLen; i++) {
+    // merge kMer (i->t order for destination locality)
+    for(int i=0; i<s->mKmerBufLen; i++) {
+        for(int t=0; t<list.size(); t++) {
             s->mKmer[i] += list[t]->mKmer[i];
         }
+    }
 
-        // merge base/read qual histogram
-        for(int i=0; i<128; i++) {
+    // merge base/read qual histogram (i->t order)
+    for(int i=0; i<128; i++) {
+        for(int t=0; t<list.size(); t++) {
             s->mBaseQualHistogram[i] += list[t]->mBaseQualHistogram[i];
         }
+    }
 
-        // merge over rep seq
+    // merge over rep seq
+    for(int t=0; t<list.size(); t++) {
         for(iter = s->mOverRepSeq.begin(); iter != s->mOverRepSeq.end(); iter++) {
             string seq = iter->first;
             s->mOverRepSeq[seq] += list[t]->mOverRepSeq[seq];

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -35,24 +35,12 @@ Stats::Stats(Options* opt, bool isRead2, int guessedCycles, int bufferMargin){
         mQ20Bases[i] = 0;
         mQ30Bases[i] = 0;
         mBaseContents[i] = 0;
-
-        mCycleQ30Bases[i] = new long[mBufLen];
-        memset(mCycleQ30Bases[i], 0, sizeof(long) * mBufLen);
-
-        mCycleQ20Bases[i] = new long[mBufLen];
-        memset(mCycleQ20Bases[i], 0, sizeof(long) * mBufLen);
-
-        mCycleBaseContents[i] = new long[mBufLen];
-        memset(mCycleBaseContents[i], 0, sizeof(long) * mBufLen);
-
-        mCycleBaseQual[i] = new long[mBufLen];
-        memset(mCycleBaseQual[i], 0, sizeof(long) * mBufLen);
     }
-    mCycleTotalBase = new long[mBufLen];
-    memset(mCycleTotalBase, 0, sizeof(long)*mBufLen);
 
-    mCycleTotalQual = new long[mBufLen];
-    memset(mCycleTotalQual, 0, sizeof(long)*mBufLen);
+    // Single allocation for all 34 cycle arrays
+    mCycleBuffer = new long[(long)CYCLE_ARRAY_COUNT * mBufLen];
+    memset(mCycleBuffer, 0, sizeof(long) * CYCLE_ARRAY_COUNT * mBufLen);
+    setCyclePointers(mBufLen);
 
     mKmerBufLen = 2<<(KMER_LEN * 2);
     mKmer = new long[mKmerBufLen];
@@ -63,69 +51,40 @@ Stats::Stats(Options* opt, bool isRead2, int guessedCycles, int bufferMargin){
     initOverRepSeq();
 }
 
+void Stats::setCyclePointers(int bufLen) {
+    for(int i=0; i<8; i++){
+        mCycleQ30Bases[i]    = mCycleBuffer + (0*8 + i) * (long)bufLen;
+        mCycleQ20Bases[i]    = mCycleBuffer + (1*8 + i) * (long)bufLen;
+        mCycleBaseContents[i]= mCycleBuffer + (2*8 + i) * (long)bufLen;
+        mCycleBaseQual[i]    = mCycleBuffer + (3*8 + i) * (long)bufLen;
+    }
+    mCycleTotalBase = mCycleBuffer + 32 * (long)bufLen;
+    mCycleTotalQual = mCycleBuffer + 33 * (long)bufLen;
+}
+
 void Stats::extendBuffer(int newBufLen){
     if(newBufLen <= mBufLen)
         return ;
 
-    long* newBuf = NULL;
+    long* newBuffer = new long[(long)CYCLE_ARRAY_COUNT * newBufLen];
+    memset(newBuffer, 0, sizeof(long) * CYCLE_ARRAY_COUNT * newBufLen);
 
-    for(int i=0; i<8; i++){
-        newBuf = new long[newBufLen];
-        memset(newBuf, 0, sizeof(long)*newBufLen);
-        memcpy(newBuf, mCycleQ30Bases[i], sizeof(long) * mBufLen);
-        delete mCycleQ30Bases[i];
-        mCycleQ30Bases[i] = newBuf;
-
-        newBuf = new long[newBufLen];
-        memset(newBuf, 0, sizeof(long)*newBufLen);
-        memcpy(newBuf, mCycleQ20Bases[i], sizeof(long) * mBufLen);
-        delete mCycleQ20Bases[i];
-        mCycleQ20Bases[i] = newBuf;
-
-        newBuf = new long[newBufLen];
-        memset(newBuf, 0, sizeof(long)*newBufLen);
-        memcpy(newBuf, mCycleBaseContents[i], sizeof(long) * mBufLen);
-        delete mCycleBaseContents[i];
-        mCycleBaseContents[i] = newBuf;
-
-        newBuf = new long[newBufLen];
-        memset(newBuf, 0, sizeof(long)*newBufLen);
-        memcpy(newBuf, mCycleBaseQual[i], sizeof(long) * mBufLen);
-        delete mCycleBaseQual[i];
-        mCycleBaseQual[i] = newBuf;
+    // Copy each of the 34 old arrays into their new positions
+    for(int a=0; a<CYCLE_ARRAY_COUNT; a++){
+        memcpy(newBuffer + a * (long)newBufLen,
+               mCycleBuffer + a * (long)mBufLen,
+               sizeof(long) * mBufLen);
     }
-    newBuf = new long[newBufLen];
-    memset(newBuf, 0, sizeof(long)*newBufLen);
-    memcpy(newBuf, mCycleTotalBase, sizeof(long)*mBufLen);
-    delete mCycleTotalBase;
-    mCycleTotalBase = newBuf;
 
-    newBuf = new long[newBufLen];
-    memset(newBuf, 0, sizeof(long)*newBufLen);
-    memcpy(newBuf, mCycleTotalQual, sizeof(long)*mBufLen);
-    delete mCycleTotalQual;
-    mCycleTotalQual = newBuf;
-
+    delete[] mCycleBuffer;
+    mCycleBuffer = newBuffer;
+    setCyclePointers(newBufLen);
     mBufLen = newBufLen;
 }
 
 Stats::~Stats() {
-    for(int i=0; i<8; i++){
-        delete mCycleQ30Bases[i];
-        mCycleQ30Bases[i] = NULL;
-
-        delete mCycleQ20Bases[i];
-        mCycleQ20Bases[i] = NULL;
-
-        delete mCycleBaseContents[i];
-        mCycleBaseContents[i] = NULL;
-
-        delete mCycleBaseQual[i];
-        mCycleBaseQual[i] = NULL;
-    }
-
-    delete mCycleTotalBase;
-    delete mCycleTotalQual;
+    delete[] mCycleBuffer;
+    mCycleBuffer = NULL;
 
     // delete memory of curves
     map<string, double*>::iterator iter;

--- a/src/stats.h
+++ b/src/stats.h
@@ -49,6 +49,8 @@ public:
     static int base2val(char base);
 
 private:
+    static const int CYCLE_ARRAY_COUNT = 34; // 8+8+8+8+1+1
+    void setCyclePointers(int bufLen);
     void extendBuffer(int newBufLen);
     string makeKmerTD(int i, int j);
     string kmer3(int val);
@@ -70,6 +72,9 @@ private:
     'G' % 8 = 7
     'N' % 8 = 6
     */
+    // Single allocation for all cycle arrays (34 arrays × mBufLen longs)
+    // Layout: [Q30[0..7] | Q20[0..7] | Content[0..7] | Qual[0..7] | TotalBase | TotalQual]
+    long *mCycleBuffer;
     long *mCycleQ30Bases[8];
     long *mCycleQ20Bases[8];
     long *mCycleBaseContents[8];


### PR DESCRIPTION
## Summary

Three phases of processing pipeline optimizations, benchmarked on Apple M4 Pro (14 cores, 48GB):

**Phase 1 — Quick wins:**
- FP division → integer multiplication in quality sliding window (filter.cpp)
- Cache `OverlapResult` to avoid 2-4 redundant `OverlapAnalysis::analyze()` calls per read pair (peprocessor.cpp)
- `alignas(128)` on hot atomics to eliminate false sharing (se/peprocessor.h)
- `appendToStringWithTag` parameter from `string` to `const char*` (read.h/cpp)

**Phase 2 — Medium optimizations:**
- `thread_local` buffer reuse for reverse complement (overlapanalysis.cpp)
- `condition_variable` replacing `usleep` polling loops (se/peprocessor)
- Relaxed atomic memory ordering: `seq_cst` → `release`/`acquire` (se/peprocessor)
- Stats merge loop reorder `t→i→j` → `i→j→t` for temporal locality (stats.cpp)

**Phase 3 — Stats restructure:**
- 34 separate `new long[]` → single contiguous buffer with `setCyclePointers()` (stats.h/cpp)
- `appendToString` 8 separate append/push_back → single `resize()` + sequential `memcpy` (read.cpp)

## Benchmark results (W=12, 5M PE pairs, median of 3 runs)

| Mode         |  W | Baseline (s) | Optimized (s) | Speedup |
|--------------|----|-------------|--------------|---------|
| **fq→fq**    | 12 |        3.59 |         2.71 | **1.32x** |
| gz→gz        | 12 |       13.29 |        12.75 | 1.04x   |
| se-fq→fq     | 12 |       13.98 |        14.01 | 1.00x   |
| stdin→stdout | 12 |        1.60 |         1.60 | 1.00x   |

Processing-bound path (PE fq→fq) shows **32% speedup** at 12 threads. gz modes are compression-bound.

## Correctness verification
- `fastp test`: 11/11 unit tests PASSED (SIMD, Read, FastqReader, OverlapAnalysis, Filter, AdapterTrimmer, BaseCorrector, PolyX, NucleotideTree, Evaluator)
- E2E output MD5: all modes bit-for-bit identical between baseline and optimized

## Test plan
- [x] Built and ran on macOS arm64 (Apple M4 Pro)
- [x] All built-in unit tests pass
- [x] E2E benchmark with MD5 verification (8/8 modes PASS)
- [ ] Build on Linux x86_64 (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)