### PR TITLE
fix: recompute overlap after trimming for merge mode

### DIFF
--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -513,10 +513,9 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
         // merging mode
         bool mergeProcessed = false;
         if(mOptions->merge.enabled && r1 && r2) {
-            if(!ovComputed) {
-                ov = OverlapAnalysis::analyze(r1, r2, mOptions->overlapDiffLimit, mOptions->overlapRequire, mOptions->overlapDiffPercentLimit/100.0);
-                ovComputed = true;
-            }
+            // Always recompute overlap on post-trim reads for merge (fixes #675)
+            ov = OverlapAnalysis::analyze(r1, r2, mOptions->overlapDiffLimit, mOptions->overlapRequire, mOptions->overlapDiffPercentLimit/100.0);
+            ovComputed = true;
             if(ov.overlapped) {
                 merged = OverlapAnalysis::merge(r1, r2, ov);
                 int result = mFilter->passFilter(merged);


### PR DESCRIPTION
## Summary

Fixes #675 — merge mode in v1.3 produces non-empty reverse unpaired output where v1.2 produced an empty file.

**Root cause:** The overlap caching optimization (introduced in `12b1738`) computes the overlap result once **before** adapter/polyX/maxLen trimming and reuses it for the merge step. After trimming shortens the reads, the stale pre-trim overlap may incorrectly report "not overlapped" for pairs that *do* overlap post-trim. These pairs skip merging and fall through to the normal PE processing path, where single-passing reads get routed to the unpaired output — producing data in a file that should be empty.

**Fix:** Always recompute the overlap on post-trim reads before the merge step, restoring v1.2 behavior.

## Test plan

- [ ] Run fastp with `--merge` and `--unpaired2` on paired-end data containing adapter sequences
- [ ] Verify reverse unpaired output matches v1.2 behavior (empty when expected)
- [ ] Verify merged output contains the same reads as v1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)