### PR TITLE
Fix deadlocks in bgzf reading

### DIFF
--- a/src/bgzf.h
+++ b/src/bgzf.h
@@ -106,7 +106,12 @@ public:
             mConsumeOffset += tocopy;
 
             if (mConsumeOffset >= s.decompLen) {
-                s.state.store(FREE, std::memory_order_release);
+                // Publish FREE under mProduceMtx so readerLoop, which waits on
+                // mProduceCv for this slot to free up, cannot miss the wakeup.
+                {
+                    std::lock_guard<std::mutex> lk(mProduceMtx);
+                    s.state.store(FREE, std::memory_order_release);
+                }
                 mConsumeOffset = 0;
                 mConsumeIdx++;
                 mProduceCv.notify_one();
@@ -145,8 +150,13 @@ private:
             }
 
             s.compLen = bsize;
-            s.state.store(COMPRESSED, std::memory_order_release);
-            mProduceIdx++;
+            // Publish the COMPRESSED slot (state + mProduceIdx, which claimSlot scans)
+            // under mDecompMtx so a decompWorker parked on mDecompCv cannot miss it.
+            {
+                std::lock_guard<std::mutex> lk(mDecompMtx);
+                s.state.store(COMPRESSED, std::memory_order_release);
+                mProduceIdx++;
+            }
             mDecompCv.notify_all();
         }
     }
@@ -173,7 +183,12 @@ private:
             int ret = isal_inflate_stateless(&ist);
             target->decompLen = (ret == ISAL_DECOMP_OK) ? (int)ist.total_out : 0;
 
-            target->state.store(READY, std::memory_order_release);
+            // Publish READY under mConsumeMtx so the consumer parked in read() on
+            // mConsumeCv cannot miss the wakeup for this slot.
+            {
+                std::lock_guard<std::mutex> lk(mConsumeMtx);
+                target->state.store(READY, std::memory_order_release);
+            }
             mConsumeCv.notify_one();
         }
     }
@@ -194,7 +209,14 @@ private:
     }
 
     void markDone(Slot& s) {
-        s.state.store(DONE, std::memory_order_release);
+        // Publish DONE under mConsumeMtx before notifying: the consumer in read()
+        // waits on mConsumeCv for READY/DONE, and at EOF this is the terminal
+        // notification (no further producer follows), so a lost wakeup here would
+        // strand the reader thread in read() forever.
+        {
+            std::lock_guard<std::mutex> lk(mConsumeMtx);
+            s.state.store(DONE, std::memory_order_release);
+        }
         mConsumeCv.notify_all();
         mDecompCv.notify_all();
     }

--- a/src/bgzf.h
+++ b/src/bgzf.h
@@ -66,7 +66,18 @@ public:
     }
 
     ~BgzfMtReader() {
-        mStop = true;
+        // Publish mStop while holding every CV's mutex before notifying. mStop is a
+        // wait predicate for all three CVs; a thread that has evaluated its predicate
+        // as false but not yet parked still holds that mutex, so taking all three here
+        // serializes the stop+notify against that gap. Storing mStop outside the locks
+        // (as before) lets notify_all() slip into that window and be missed, leaving a
+        // worker parked forever and the join() below hung — an intermittent deadlock.
+        {
+            std::lock_guard<std::mutex> l1(mProduceMtx);
+            std::lock_guard<std::mutex> l2(mDecompMtx);
+            std::lock_guard<std::mutex> l3(mConsumeMtx);
+            mStop = true;
+        }
         mDecompCv.notify_all();
         mProduceCv.notify_all();
         mConsumeCv.notify_all();


### PR DESCRIPTION
While working on [chelae](https://github.com/fulcrumgenomics/chelae) I spent quite a bit of time benchmarking fastp, and ran into hangs in fastp often enough that it was problematic for me.  They are infrequent, but painful since fastp just never returns, and has to then be monitored and killed if it sits at 0% CPU for long enough.

I finally got around to spending some time debugging it today (with Claude's assistance).  We set up a harness to read small (30k reads) paired-end bgzipped fastqs, with several threads and compressed outputs.  With the current version on `main` I hit a deadlock something like once in every thousand invocations.  The first commit fixes the one that hit most frequently.  Once that was fixed, my observed rate dropped to maybe 1/2500-5000.  The second commit resolves all places with similar deadlock-capable setups in the bgzf read layer.

After both commits, I've run >> 10,000 iterations of my test, with no deadlocks.