### PR TITLE
Fix parallel.py read2 detection when read1 flag substring appears in parent dir path

### DIFF
--- a/parallel.py
+++ b/parallel.py
@@ -92,7 +92,8 @@ def processDir(folder, options):
             opt = copy.copy(options)
             read1 = path
             opt.read1_file = read1
-            read2 = read1.replace(read1name, read2name)
+            dirn, basen = os.path.dirname(read1), os.path.basename(read1)
+            read2 = os.path.join(dirn, basen.replace(read1name, read2name))        
             if os.path.exists(read2):
                 opt.read2_file = read2
                 processed.add(read2)


### PR DESCRIPTION
str.replace() in processDir() was applied to the full file path, not just the basename. If read1_flag (e.g. "_1") also appears earlier in the path (e.g. dir named "Project_1000"), the substitution corrupts the path and read2 was never found, silently falling back to single-end mode. The fix restricts the replcae to os.path.basename().