### PR TITLE
Makefile: create BINDIR before installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ clean:
 	@rm -f $(TARGET)
 
 install:
+	mkdir -p $(BINDIR)
 	install $(TARGET) $(BINDIR)/$(TARGET)
 	@echo "Installed."
 


### PR DESCRIPTION
`make install` fails when `$(PREFIX)/bin` does not exist yet, because `install` does not create the destination directory:

```
install fastp /path/to/prefix/bin/fastp
install: /path/to/prefix/bin/fastp: No such file or directory
```

This shows up in any staged install into a fresh prefix (distro/Homebrew packaging, DESTDIR-style installs, containers), where packagers currently have to `mkdir -p` the bin directory themselves before calling `make install`.

Adding `mkdir -p $(BINDIR)` to the `install` target fixes it and is a no-op when the directory already exists.

Same patch sent to fastplong: https://github.com/OpenGene/fastplong/pull/44

Tested: `make install PREFIX=/tmp/fresh-prefix` now succeeds where it previously failed.