### PR TITLE
Reject truncated BGZF blocks instead of treating them as EOF

### DIFF
--- a/scripts/test_bgzf_truncated_input.py
+++ b/scripts/test_bgzf_truncated_input.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Run: python3 scripts/test_bgzf_truncated_input.py ./fastp
+
+Synthetic BGZF fixtures; no external data or compression tools required.
+"""
+import gzip
+import pathlib
+import struct
+import subprocess
+import sys
+import tempfile
+import zlib
+
+
+def block(data):
+    compressor = zlib.compressobj(wbits=-15)
+    payload = compressor.compress(data) + compressor.flush()
+    size = 18 + len(payload) + 8
+    assert size <= 65536
+    return (b'\x1f\x8b\x08\x04' + b'\x00'*4 + b'\x00\xff' +
+            struct.pack('<H', 6) + b'BC' + struct.pack('<HH', 2, size-1) +
+            payload + struct.pack('<II', zlib.crc32(data), len(data)))
+
+
+def main():
+    exe = str(pathlib.Path(sys.argv[1]).resolve())
+    first = b'@first\nACGTACGTACGTACGTACGT\n+\nIIIIIIIIIIIIIIIIIIII\n'
+    second = first.replace(b'first', b'second')
+    a, b, eof = block(first), block(second), block(b'')
+    malformed_size = bytearray(b)
+    malformed_size[16:18] = struct.pack('<H', 0)
+    cases = [
+        ('valid', a+b+eof, first+second, None),
+        ('no_eof_marker', a+b, first+second, None),
+        ('concatenated', a+eof+b+eof, first+second, None),
+        ('partial_header', a+b[:9], None, 'Truncated BGZF block header'),
+        ('partial_payload', a+b[:20], None, 'Truncated BGZF block body'),
+        ('partial_trailer', a+b[:-3], None, 'Truncated BGZF block body'),
+        ('undersized_block', a+bytes(malformed_size), None, 'Invalid BGZF block size'),
+    ]
+    failed = 0
+    with tempfile.TemporaryDirectory(prefix='fastp-bgzf-test-') as tmp:
+        root = pathlib.Path(tmp)
+        for threads in (1, 4):
+            for name, content, expected, diagnostic in cases:
+                source = root/('%s-%d.fq.gz' % (name, threads))
+                output = root/('%s-%d.out.fq' % (name, threads))
+                source.write_bytes(content)
+                if expected is not None:
+                    assert gzip.decompress(content) == expected
+                cmd = [exe, '-i', str(source), '-o', str(output),
+                       '-w', str(threads), '-A', '-Q', '-L', '-G',
+                       '--dont_eval_duplication', '-j', '/dev/null', '-h', '/dev/null']
+                try:
+                    run = subprocess.run(cmd, capture_output=True, timeout=30)
+                    if diagnostic:
+                        ok = run.returncode > 0 and diagnostic.encode() in run.stderr
+                    else:
+                        ok = (run.returncode == 0 and output.exists() and
+                              output.read_bytes() == expected)
+                    detail = 'exit=%d' % run.returncode
+                except subprocess.TimeoutExpired:
+                    ok, detail = False, 'timeout'
+                print('%s %s threads=%d %s' %
+                      ('PASS' if ok else 'FAIL', name, threads, detail))
+                failed += not ok
+    return bool(failed)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/bgzf.h
+++ b/src/bgzf.h
@@ -10,6 +10,7 @@
 #include <condition_variable>
 #include <vector>
 #include <isa-l/igzip_lib.h>
+#include "util.h"
 
 static const int BGZF_HEADER_SIZE = 18;
 static const int BGZF_MAX_BLOCK_SIZE = 65536;
@@ -136,14 +137,25 @@ private:
             }
 
             size_t n = fread(header, 1, BGZF_HEADER_SIZE, mFp);
-            if (n < BGZF_HEADER_SIZE) { markDone(s); break; }
+            if (ferror(mFp))
+                error_exit("BGZF input read error while reading block header");
+            if (n == 0) { markDone(s); break; }
+            if (n < BGZF_HEADER_SIZE)
+                error_exit("Truncated BGZF block header");
 
             uint32_t bsize = bgzfBlockSize(header);
-            if (bsize == 0 || bsize > BGZF_MAX_BLOCK_SIZE) { markDone(s); break; }
+            // Reject undersized blocks before subtracting the header length.
+            // A BGZF block includes the header, deflate stream and 8-byte trailer.
+            if (bsize < BGZF_HEADER_SIZE + 8 || bsize > BGZF_MAX_BLOCK_SIZE)
+                error_exit("Invalid BGZF block size or header");
 
             memcpy(s.comp, header, BGZF_HEADER_SIZE);
             size_t rest = bsize - BGZF_HEADER_SIZE;
-            if (fread(s.comp + BGZF_HEADER_SIZE, 1, rest, mFp) < rest) { markDone(s); break; }
+            size_t bodyRead = fread(s.comp + BGZF_HEADER_SIZE, 1, rest, mFp);
+            if (ferror(mFp))
+                error_exit("BGZF input read error while reading block body");
+            if (bodyRead < rest)
+                error_exit("Truncated BGZF block body");
 
             if (bsize == 28) {
                 uint32_t isize = s.comp[24]|(s.comp[25]<<8)|(s.comp[26]<<16)|(s.comp[27]<<24);


### PR DESCRIPTION
### Summary

The BGZF reader currently treats incomplete block headers and bodies as normal end-of-file. Consequently, truncated input can produce incomplete output while fastp exits successfully.

This PR distinguishes these failures from clean EOF.

### Changes

- Reject partial BGZF headers and bodies with explicit errors.
- Check input-stream read errors.
- Reject undersized blocks before subtracting the header length, preventing unsigned underflow.
- Preserve existing handling of embedded EOF markers and complete streams without a terminal EOF marker.

This is separate from the concatenated-stream fix in #712 and does not depend on #716.

### Tests

Added synthetic regression tests covering:

- Valid BGZF input.
- Complete input without a terminal EOF marker.
- Concatenated BGZF streams.
- Partial headers, payloads, and trailers.
- Undersized blocks.

Each case runs with `-w 1` and `-w 4`.

```sh
python3 scripts/test_bgzf_truncated_input.py ./fastp
```

On macOS ARM64, all 14 cases pass with the patch. The unchanged BGZF reader incorrectly exits successfully for all eight malformed-input cases.

### Scope

This patch addresses block framing and read failures. It does not implement comprehensive gzip-header, CRC, or decompression-error validation. Linux execution and injected input-stream I/O errors have not been tested.