### PR TITLE
Return a nonzero exit status for detected paired-end read-count mismatches

### DIFF
--- a/scripts/test_paired_read_counts.py
+++ b/scripts/test_paired_read_counts.py
@@ -1,0 +1,41 @@
+"""Run: python3 scripts/test_paired_read_counts.py ./fastp (POSIX)."""
+import pathlib
+import subprocess
+import tempfile
+import sys
+
+exe = str(pathlib.Path(sys.argv[1]).resolve())
+failures = 0
+with tempfile.TemporaryDirectory(prefix='fastp-pairs-') as tmp:
+    root = pathlib.Path(tmp)
+    for threads in (1, 4):
+        for n, m, limit in ((999,999,0),(1000,1000,0),(1001,1001,0),
+                            (999,1000,0),(1000,999,0),(1000,1001,0),
+                            (1001,1000,0),(41000,41001,0),(41001,41000,0),
+                            (1000,1001,500)):
+            paths = [root/'r1.fq', root/'r2.fq']
+            for mate, count in enumerate((n,m)):
+                paths[mate].write_text(''.join('@r%d/%d\n%s\n+\n%s\n' %
+                    (i,mate+1,'ACGT'*10,'I'*40) for i in range(count)))
+            cmd = [exe,'-i',str(paths[0]),'-I',str(paths[1]),'-o',str(root/'o1.fq'),
+                   '-O',str(root/'o2.fq'),'-w',str(threads),'-A','-Q','-L','-G',
+                   '--dont_eval_duplication','-j','/dev/null','-h','/dev/null']
+            if limit:
+                cmd += ['--reads_to_process',str(limit)]
+            try:
+                run = subprocess.run(cmd,capture_output=True,timeout=5)
+                if n != m and not limit:
+                    ok = (run.returncode > 0 and
+                          b'Paired-end input files contain different numbers of reads' in run.stderr)
+                else:
+                    expected = limit or n
+                    ok = run.returncode == 0
+                    for mate in (1, 2):
+                        output = root/('o%d.fq' % mate)
+                        ok = ok and output.exists() and output.read_bytes().count(b'\n') == expected*4
+                failures += not ok
+                print('PASS' if ok else 'FAIL',n,m,threads,limit,'exit',run.returncode,flush=True)
+            except subprocess.TimeoutExpired:
+                failures += 1
+                print(n,m,threads,limit,'TIMEOUT',flush=True)
+sys.exit(bool(failures))

--- a/src/peprocessor.cpp
+++ b/src/peprocessor.cpp
@@ -365,8 +365,8 @@ bool PairEndProcessor::processPairEnd(ReadPack* leftPack, ReadPack* rightPack, T
         cerr << "WARNING: different read numbers of the " << mPackProcessedCounter << " pack" << endl;
         cerr << "Read1 pack size: " << leftPack->count << endl;
         cerr << "Read2 pack size: " << rightPack->count << endl;
-        cerr << "Ignore the unmatched reads" << endl << endl;
-        shouldStopReading = true;
+        error_exit("Paired-end input files contain different numbers of reads: "
+            + mOptions->in1 + " and " + mOptions->in2);
     }
     int tid = config->getThreadId();
 


### PR DESCRIPTION
### Summary

When paired input packs contain different numbers of reads, fastp currently warns, discards unmatched reads, and can finish with exit status 0.

This PR changes the existing mismatch check to fail explicitly and identify both input files.

### Changes

- Use `error_exit()` when paired-pack counts differ.
- Preserve the existing pack-count diagnostics.
- Include both input filenames in the fatal error.

### Regression tests

Added synthetic tests covering:

- Both shorter-mate directions.
- Counts around the 1,000-read pack boundary.
- Inputs exceeding 40,000 reads.
- One and four processing threads.
- Equal inputs and intentional `--reads_to_process` limits.

Run with:

```sh
python3 scripts/test_paired_read_counts.py ./fastp
```

On macOS ARM64, all 20 cases pass with the patch. Unmodified Conda fastp 1.3.6 returns success for all 12 unequal-input cases.

### Relationship to #694

Related to #694: this addresses failure reporting when a count mismatch is detected. I did not reproduce the historical hang in these tests, so this PR does not claim to resolve every deadlock scenario described there.

### Scope

This patch concerns the existing count check for separate paired-end files. It does not validate read identifiers, change interleaved input handling, or scan beyond an intentional processing limit.

Linux execution has not been tested.